### PR TITLE
Fixes Kitchen providers to use vanilla ingredients

### DIFF
--- a/Components/SRebuildMysteryKitchen.cs
+++ b/Components/SRebuildMysteryKitchen.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace KitchenMysteryMenu.Components
+{
+    public struct SRebuildMysteryKitchen : IComponentData
+    {
+        public int PrevDish;
+        public int CurDish;
+        //[NativeFixedLength(2)]
+        //public NativeArray<int> Ingredients;
+    }
+}

--- a/Patches/RebuildKitchen_Patch.cs
+++ b/Patches/RebuildKitchen_Patch.cs
@@ -18,47 +18,47 @@ using Unity.Entities;
 
 namespace KitchenMysteryMenu.Patches
 {
-    [HarmonyPatch(typeof(RebuildKitchen))]
-    public class RebuildKitchen_Patch
-    {
-        static readonly int MYSTERY_MENU_ID = GDOUtils.GetCastedGDO<Dish, MysteryMenuDish>().ID;
-        static KitchenLogger Logger = new KitchenLogger("KitchenMysteryMenu");
-        static EntityQuery MysteryProvidersQuery = PatchController.StaticGetEntityQuery(
-                    new QueryHelper()
-                    .All(typeof(RebuildKitchen.CFranchiseKitchenAppliance),
-                        typeof(CItemProvider),
-                        typeof(CMysteryMenuProvider))
-                );
+    //[HarmonyPatch(typeof(RebuildKitchen))]
+    //public class RebuildKitchen_Patch
+    //{
+    //    static readonly int MYSTERY_MENU_ID = GDOUtils.GetCastedGDO<Dish, MysteryMenuDish>().ID;
+    //    static KitchenLogger Logger = new KitchenLogger("KitchenMysteryMenu");
+    //    static EntityQuery MysteryProvidersQuery = PatchController.StaticGetEntityQuery(
+    //                new QueryHelper()
+    //                .All(typeof(RebuildKitchen.CFranchiseKitchenAppliance),
+    //                    typeof(CItemProvider),
+    //                    typeof(CMysteryMenuProvider))
+    //            );
 
-        [HarmonyPostfix]
-        [HarmonyPatch("RecreateAppliances")]
-        public static void RecreateAppliances_Postfix(Dish dish)
-        {
-            Logger.LogInfo($"dish.ID = {dish.ID}; dish.Name = {dish.Name}; MysteryMenuID = {MYSTERY_MENU_ID}");
-            if (dish.ID != MYSTERY_MENU_ID)
-            {
-                return;
-            }
+    //    [HarmonyPostfix]
+    //    [HarmonyPatch("RecreateAppliances")]
+    //    public static void RecreateAppliances_Postfix(Dish dish)
+    //    {
+    //        Logger.LogInfo($"dish.ID = {dish.ID}; dish.Name = {dish.Name}; MysteryMenuID = {MYSTERY_MENU_ID}");
+    //        if (dish.ID != MYSTERY_MENU_ID)
+    //        {
+    //            return;
+    //        }
 
-            NativeArray<int> itemIDs = new();
-            itemIDs.AddItem(ItemReferences.Meat);
-            itemIDs.AddItem(ItemReferences.Flour);
-            using var mpEntities = MysteryProvidersQuery.ToEntityArray(Allocator.Temp);
-            Logger.LogInfo($"mpEntities: {mpEntities}\n" +
-                $"mpEntities.Length: {mpEntities.Length}");
+    //        NativeArray<int> itemIDs = new();
+    //        itemIDs.AddItem(ItemReferences.Meat);
+    //        itemIDs.AddItem(ItemReferences.Flour);
+    //        using var mpEntities = MysteryProvidersQuery.ToEntityArray(Allocator.Temp);
+    //        Logger.LogInfo($"mpEntities: {mpEntities}\n" +
+    //            $"mpEntities.Length: {mpEntities.Length}");
 
-            // Compare Minimum Ingredients in the dish to the provided items by the providers. Modify the data
-            // of the matching entity to use the original ingredient instead of the Mystery form.
-            // TODO?: After MVP release, instead, base it off a SelectMysteryMenu-selected pair of ingredients
-            //      that have been implemented, perhaps only if there's a "randomize ingredients" appliance.
-            for (int i = 0; i < mpEntities.Length; i++)
-            {
-                var ent = mpEntities[i];
-                var cItemProvider = CItemProvider.InfiniteItemProvider(itemIDs[i % itemIDs.Length]);
-                PatchController.StaticRemoveComponentData<CItemProvider>(ent);
-                PatchController.StaticAddComponentData(ent, cItemProvider);
-            }
-        }
+    //        // Compare Minimum Ingredients in the dish to the provided items by the providers. Modify the data
+    //        // of the matching entity to use the original ingredient instead of the Mystery form.
+    //        // TODO?: After MVP release, instead, base it off a SelectMysteryMenu-selected pair of ingredients
+    //        //      that have been implemented, perhaps only if there's a "randomize ingredients" appliance.
+    //        for (int i = 0; i < mpEntities.Length; i++)
+    //        {
+    //            var ent = mpEntities[i];
+    //            var cItemProvider = CItemProvider.InfiniteItemProvider(itemIDs[i % itemIDs.Length]);
+    //            PatchController.StaticRemoveComponentData<CItemProvider>(ent);
+    //            PatchController.StaticAddComponentData(ent, cItemProvider);
+    //        }
+    //    }
 
         /* TODO: After providing a lobby button to swap available ingredients, need to make sure the cats order
          *      the right menu. Down-the-line feature. */
@@ -135,5 +135,5 @@ namespace KitchenMysteryMenu.Patches
         // Need to patch over RebuildKitchen to remove menu item entities that can't be ordered
         // Might not be necessary depending on if AlsoAddRecipes adding the cards also adds the dishes *in the restaurant*,
         //  unlike with the kitchen
-    }
+    //}
 }

--- a/Systems/RebuildMysteryKitchen.cs
+++ b/Systems/RebuildMysteryKitchen.cs
@@ -1,0 +1,109 @@
+﻿using HarmonyLib;
+using Kitchen;
+using KitchenLib.References;
+using KitchenMysteryMenu.Components;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace KitchenMysteryMenu.Systems
+{
+    internal class RebuildMysteryKitchen : FranchiseSystem
+    {
+        private EntityQuery HqItemProviders;
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+            HqItemProviders = GetEntityQuery(typeof(RebuildKitchen.CFranchiseKitchenAppliance), typeof(CItemProvider));
+            RequireSingletonForUpdate<RebuildKitchen.SCurrentKitchen>();
+        }
+
+        protected override void OnUpdate()
+        {
+            Mod.Logger.LogInfo("RebuildMysteryKitchen Updating");
+            var sRebuildMysteryKitchen = GetOrCreate<SRebuildMysteryKitchen>();
+
+            if (!TryGetSingleton<RebuildKitchen.SCurrentKitchen>(out var sCurrentKitchen))
+            {
+                Mod.Logger.LogInfo("RebuildMysteryKitchen - SCurrentKitchen not created yet.");
+                return;
+            }
+            int currentDish = sCurrentKitchen.Dish;
+            sRebuildMysteryKitchen.CurDish = currentDish;
+
+            // If the dish hasn't changed since the last update, or the current dish isn't Mystery Menu, we're done.
+            // #TODO - Eventual QoL appliance to trigger mystery ingredients randomization in the lobby for practice purposes
+            //      without unloading and loading the dish itself.
+            if (sRebuildMysteryKitchen.CurDish == sRebuildMysteryKitchen.PrevDish)
+            {
+                return;
+            }
+
+            // Update the Prev Dish, then check if we need to update the Item Providers
+            sRebuildMysteryKitchen.PrevDish = currentDish;
+            SetSingleton(sRebuildMysteryKitchen);
+            if (currentDish != References.MYSTERY_MENU_ID)
+            {
+                return;
+            }
+
+            // Finally, actually update the mystery providers to (TODO: randomize and) set the ingredients so that they're
+            //  vanilla ingredients and not the Mystery placeholders.
+            UpdateMysteryIngredients();
+            Mod.Logger.LogInfo("RebuildMysteryKitchen - Done updating ingredients");
+        }
+
+        private void UpdateMysteryIngredients()
+        {
+            Mod.Logger.LogInfo("RebuildMysteryKitchen - It's the Mystery Menu dish!");
+            List<int> itemIDs = GetReplacementIngredients();
+            int ingredientIndex = 0;
+            using var itemProviders = HqItemProviders.ToEntityArray(Allocator.Temp);
+            using var existingCItemProviders = HqItemProviders.ToComponentDataArray<CItemProvider>(Allocator.Temp);
+            Mod.Logger.LogInfo("RebuildMysteryKitchen - Updating ingredients");
+            Mod.Logger.LogInfo($"itemproviders: {itemProviders}; itemproviders.Length: {itemProviders.Length}");
+            Mod.Logger.LogInfo($"existingComp: {existingCItemProviders}; existing.Length: {existingCItemProviders.Length}");
+            for (int i = 0; i < itemProviders.Length; i++)
+            {
+                Mod.Logger.LogInfo($"looping: {i}");
+                var entity = itemProviders[i];
+                var cItemProvider = existingCItemProviders[i];
+                Mod.Logger.LogInfo($"entity = {entity}; comp = {cItemProvider}");
+
+                // Plate & Wok Stacks are also Item Providers, so don't change those.
+                if (cItemProvider.ProvidedItem == ItemReferences.Plate
+                    || cItemProvider.ProvidedItem == ItemReferences.Wok)
+                {
+                    continue;
+                }
+
+                Mod.Logger.LogInfo($"It's an ingredient!");
+                Mod.Logger.LogInfo($"Setting to index: {ingredientIndex}");
+                Mod.Logger.LogInfo($"before itemID = {cItemProvider.ProvidedItem}");
+                Mod.Logger.LogInfo($"itemIDs = {itemIDs}; itemIDs.Length = {itemIDs.Count}");
+                Mod.Logger.LogInfo($"after itemID? = {itemIDs[ingredientIndex]}");
+                /*CItemProvider newComponentData = CItemProvider.InfiniteItemProvider(itemIDs[ingredientIndex])*/;
+                cItemProvider.ProvidedItem = itemIDs[ingredientIndex];
+                EntityManager.SetComponentData(entity, cItemProvider);
+                Mod.Logger.LogInfo("Component Data Set! Cyclically increment ingredientIndex.");
+                ingredientIndex = (ingredientIndex + 1) % itemIDs.Count;
+            }
+        }
+
+        private List<int> GetReplacementIngredients()
+        {
+            List<int> itemIDs = new()
+            {
+                ItemReferences.Meat,
+                ItemReferences.Flour
+            };
+            return itemIDs;
+        }
+    }
+}

--- a/Utils/References.cs
+++ b/Utils/References.cs
@@ -1,0 +1,16 @@
+﻿using KitchenData;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Utils
+{
+    internal class References
+    {
+        public static readonly int MYSTERY_MENU_ID = GDOUtils.GetCastedGDO<Dish, MysteryMenuDish>().ID;
+    }
+}


### PR DESCRIPTION
* Adds new FranchiseSystem to rebuild the kitchen when Mystery Menu is selected
* Removes the Harmony Patch except as reference material
* Uses List<> instead of NativeArray<> for the generic collection of ingredients-to-be-substituted-in.