### PR TITLE
Add base mains

### DIFF
--- a/Customs/Dishes/Breakfast/MysteryBreakfastBaseDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastBaseDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Knead flour to make dough, then cook to make bread. Interact to cut a slice and cook to make toast." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour\n" + 
+                "Knead flour to make dough, then cook to make bread. Interact to cut a slice and cook to make toast." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Burger
+{
+    public class MysteryBurgerBaseDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Burger Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BurgerBase);
+        public override DishType Type => DishType.Base;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Cook burger patty, add burger bun, then serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Burger",
+                Description = "Adds burgers as a main when <b>Burger Bun</b> and <b>Burger Patty</b> are present",
+                FlavourText = "Bah dap bap bap baaah!"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BurgerBun),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BurgerPattyRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Burger
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook burger patty, add burger bun, then serve." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Burger Bun, Burger Patty\n" + 
+                "Cook burger patty, add burger bun, then serve." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Dumplings/MysteryDumplingsBaseDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsBaseDish.cs
@@ -8,12 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
 {
-    public class MysteryHotdogBaseDish : GenericMysteryDish
+    public class MysteryDumplingsBaseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Hot Dog Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogBase);
+        protected override string NameTag => "Mystery Dumplings Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Dumplings);
         public override DishType Type => DishType.Base;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,20 +22,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 1;
+        public override int Difficulty => 3;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Hot Dog Bun, Hot Dog\n" + 
-                "Cook hot dog link, add hot dog bun, then serve.\n" +
-                "You don't need to worry about Extra Ketchup with only the base Mystery Menu." }
+                "<color=yellow>Requires ingredients:</color> Flour, Carrot, Meat\n" +
+                "Knead (or add water to) flour to make dough. Chop carrots and meat. " +
+                "Combine the dough with the chopped carrots and meat, knead to fold, then cook." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Hot Dog",
-                Description = "Adds hot dogs as a main when <b>Hot Dog Buns</b> and <b>Hot Dog Links</b> are present",
+                Name = "Mystery - Dumplings",
+                Description = "Adds dumplings as a main when <b>Flour</b>, <b>Meat</b>, and <b>Carrots</b> are present",
                 FlavourText = ""
             })
         };
@@ -44,15 +44,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.DumplingsPlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogBun),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Fish/MysteryFishBlueDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishBlueDish.cs
@@ -26,7 +26,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook blue fish, plate, and serve." }
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Blue Fish\n" + 
+                "Cook blue fish, plate, and serve." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Fish/MysteryFishBlueDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishBlueDish.cs
@@ -1,0 +1,58 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishBlueDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Blue Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishBase);
+        public override DishType Type => DishType.Base;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Cook blue fish, plate, and serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery Fish - Blue",
+                Description = "Adds <b>Blue Fish</b> as a main when it is present",
+                FlavourText = "Just keep swimming!"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishBluePlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishBlueRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Fish/MysteryFishPinkDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishPinkDish.cs
@@ -1,4 +1,5 @@
 ﻿using KitchenData;
+using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMenu.Utils;
@@ -8,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
 {
-    public class MysteryHotdogBaseDish : GenericMysteryDish
+    public class MysteryFishPinkDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Hot Dog Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogBase);
+        protected override string NameTag => "Mystery Fish Pink Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishBase);
         public override DishType Type => DishType.Base;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,33 +27,30 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Hot Dog Bun, Hot Dog\n" + 
-                "Cook hot dog link, add hot dog bun, then serve.\n" +
-                "You don't need to worry about Extra Ketchup with only the base Mystery Menu." }
+                "<color=yellow>Requires ingredient:</color> Pink Fish\n" + 
+                "Cook pink fish, plate, and serve." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Hot Dog",
-                Description = "Adds hot dogs as a main when <b>Hot Dog Buns</b> and <b>Hot Dog Links</b> are present",
+                Name = "Mystery - Fish - Pink",
+                Description = "Adds <b>Pink Fish</b> as a main when it is present",
                 FlavourText = ""
             })
         };
-
         public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishPinkPlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogBun),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishPinkRaw)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Fish/MysteryFishRedDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishRedDish.cs
@@ -1,0 +1,58 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishPinkDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Pink Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishBase);
+        public override DishType Type => DishType.Base;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Cook pink fish, plate, and serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Fish - Pink",
+                Description = "Adds <b>Pink Fish</b> as a main when it is present",
+                FlavourText = ""
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishPinkPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishPinkRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/HotDog/MysteryHotDogBaseDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotDogBaseDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+{
+    public class MysteryHotdogBaseDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Hot Dog Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogBase);
+        public override DishType Type => DishType.Base;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Cook hot dog link, add hot dog bun, then serve.\n" +
+                "You don't need to worry about Extra Ketchup with only the base Mystery Menu." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Hot Dog",
+                Description = "Adds hot dogs as a main when <b>Hot Dog Buns</b> and <b>Hot Dog Links</b> are present",
+                FlavourText = ""
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogBun),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuBaseMainsDish.cs
+++ b/Customs/Dishes/MysteryMenuBaseMainsDish.cs
@@ -4,6 +4,9 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMenu;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
+using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Fish;
+using KitchenMysteryMenu.Customs.Dishes.HotDog;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
@@ -66,6 +69,10 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             // Add the Mystery versions of every base main
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishBlueDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishPinkDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMeatDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>(),

--- a/Customs/Dishes/MysteryMenuBaseMainsDish.cs
+++ b/Customs/Dishes/MysteryMenuBaseMainsDish.cs
@@ -5,7 +5,9 @@ using KitchenLib.Utils;
 using KitchenMysteryMenu;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
 using KitchenMysteryMenu.Customs.Ingredients;
 using KitchenMysteryMenu.Utils;
 using System;
@@ -50,6 +52,8 @@ namespace KitchenMysteryMenu.Customs.Dishes
             GDOUtils.GetCastedGDO<Item, MysteryFlour>(),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Wok)
+            //,
+            //(Item)GDOUtils.GetExistingGDO(ItemReferences.Pot)
         };
         public override HashSet<Process> RequiredProcesses => new()
         {
@@ -63,8 +67,14 @@ namespace KitchenMysteryMenu.Customs.Dishes
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>(),
-            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMeatDish>()
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMeatDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladTomatoDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBroccoliDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryCarrotDish>()
         };
+
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English, "Make other base main recipes with the given ingredients, then plate." }

--- a/Customs/Dishes/MysteryMenuBaseMainsDish.cs
+++ b/Customs/Dishes/MysteryMenuBaseMainsDish.cs
@@ -5,10 +5,13 @@ using KitchenLib.Utils;
 using KitchenMysteryMenu;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Dumplings;
 using KitchenMysteryMenu.Customs.Dishes.Fish;
 using KitchenMysteryMenu.Customs.Dishes.HotDog;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Dishes.Pizza;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
 using KitchenMysteryMenu.Customs.Dishes.StirFry;
 using KitchenMysteryMenu.Customs.Dishes.Turkey;
@@ -55,7 +58,8 @@ namespace KitchenMysteryMenu.Customs.Dishes
             GDOUtils.GetCastedGDO<Item, MysteryMeat>(),
             GDOUtils.GetCastedGDO<Item, MysteryFlour>(),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate),
-            (Item)GDOUtils.GetExistingGDO(ItemReferences.Wok)
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Wok),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot)
             //,
             //(Item)GDOUtils.GetExistingGDO(ItemReferences.Pot)
         };
@@ -70,31 +74,43 @@ namespace KitchenMysteryMenu.Customs.Dishes
             // Add the Mystery versions of every base main
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryDumplingsBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishBlueDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishPinkDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMeatDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPizzaBaseDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladTomatoDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySpaghettiBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryRiceDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBroccoliDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryCarrotDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>()
         };
 
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Make other base main recipes with the given ingredients, then plate." }
+            { Locale.English, "Make other base main recipes with the given ingredients, then plate.\n" +
+                "All available Mystery Recipes will have a line at the top like \"<color=yellow>Requires ingredients:</color>\"; " +
+                "all ingredients listed in that paragraph must be available from any provider (mysterious or static) for " +
+                "customers to order it.\n" +
+                "Text in <i>italics</i> indicates a reference to at least one other recipe."
+            }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
                 Name = "Mystery Menu",
-                Description = "Adds all default base mains as mains",
+                Description = "Adds all default base mains as mains and provides two Mystery Ingredient Providers to make them.",
                 FlavourText = "Available ingredients will vary each day.\n" +
                     "Make sure you're ready for any and every recipe you have that those ingredients can make!"
             })

--- a/Customs/Dishes/MysteryMenuBaseMainsDish.cs
+++ b/Customs/Dishes/MysteryMenuBaseMainsDish.cs
@@ -72,6 +72,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladTomatoDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryRiceDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBroccoliDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryCarrotDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>()

--- a/Customs/Dishes/MysteryMenuBaseMainsDish.cs
+++ b/Customs/Dishes/MysteryMenuBaseMainsDish.cs
@@ -8,6 +8,7 @@ using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
 using KitchenMysteryMenu.Customs.Dishes.StirFry;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
 using KitchenMysteryMenu.Customs.Ingredients;
 using KitchenMysteryMenu.Utils;
 using System;
@@ -64,15 +65,16 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
         {
             // Add the Mystery versions of every base main
-            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMeatDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladTomatoDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBroccoliDish>(),
-            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryCarrotDish>()
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryCarrotDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>()
         };
 
         public override Dictionary<Locale, string> Recipe => new()

--- a/Customs/Dishes/Pies/MysteryPiesBaseDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesBaseDish.cs
@@ -25,7 +25,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Knead flour (or add water) to make dough, then knead into pie crust. Add meat and cook." }
+            {
+                Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour + <i>variant filling</i>\n" +
+                "Knead flour (or add water) to make dough, then knead into pie crust. Add filling and cook."
+            }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Pies/MysteryPiesMeatDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesMeatDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Knead flour (or add water) to make dough, then knead into pie crust. Add meat and cook." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Meat\n" + 
+                "Knead flour (or add water) to make dough, then knead into pie crust. Add meat and cook." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Pizza/MysteryPizzaBaseDish.cs
+++ b/Customs/Dishes/Pizza/MysteryPizzaBaseDish.cs
@@ -1,5 +1,4 @@
 ﻿using KitchenData;
-using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMenu.Utils;
@@ -9,12 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Fish
+namespace KitchenMysteryMenu.Customs.Dishes.Pizza
 {
-    public class MysteryFishPinkDish : GenericMysteryDish
+    public class MysteryPizzaBaseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Fish Pink Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishBase);
+        protected override string NameTag => "Mystery Pizza Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PizzaBase);
         public override DishType Type => DishType.Base;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -23,32 +22,40 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 1;
+        public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook pink fish, plate, and serve." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Oil, Tomato, Cheese\n" +
+                "Knead (or add water to) flour to make dough, then combine with oil to make Pizza Crust. " +
+                "Chop a tomato twice to make tomato sauce. Chop cheese. " +
+                "Combine the pizza crust with the sauce and cheese, then cook. Portions 4 slices." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Fish - Pink",
-                Description = "Adds <b>Pink Fish</b> as a main when it is present",
+                Name = "Mystery - Pizza",
+                Description = "Adds pizzas as a main when <b>Flour</b>, <b>Oil</b>, <b>Tomato</b>, and <b>Cheese</b> are present",
                 FlavourText = ""
             })
         };
+
         public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishPinkPlated),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PizzaPlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishPinkRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Oil),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Salad/MysterySaladBaseDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladBaseDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop lettuce and plate." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Lettuce\n" + 
+                "Chop lettuce and plate." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Salad/MysterySaladTomatoDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladTomatoDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop tomato once and serve when ordered with salad." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Salad</i>, Tomato\n" + 
+                "Chop tomato once and serve when ordered with salad." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBaseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBaseDish.cs
@@ -8,12 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
 {
-    public class MysteryHotdogBaseDish : GenericMysteryDish
+    public class MysterySpaghettiBaseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Hot Dog Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogBase);
+        protected override string NameTag => "Mystery Spaghetti Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(1764920765/*Spaghetti Base Dish - "Pomodoro"*/);
         public override DishType Type => DishType.Base;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,20 +22,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 1;
+        public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Hot Dog Bun, Hot Dog\n" + 
-                "Cook hot dog link, add hot dog bun, then serve.\n" +
-                "You don't need to worry about Extra Ketchup with only the base Mystery Menu." }
+                "<color=yellow>Requires ingredients:</color> Tomato, Spaghetti\n" +
+                "Put raw spaghetti into a pot with water and boil, then empty the water into the trash. " +
+                "Chop tomato twice to make sauce. Combine boiled pasta on a plate with the sauce." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Hot Dog",
-                Description = "Adds hot dogs as a main when <b>Hot Dog Buns</b> and <b>Hot Dog Links</b> are present",
+                Name = "Mystery - Spaghetti",
+                Description = "Adds spaghetti as a main when <b>Tomatoes</b> and <b>Raw Spaghetti</b> are present",
                 FlavourText = ""
             })
         };
@@ -44,15 +44,15 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated),
+                Item = (Item)GDOUtils.GetExistingGDO(1900532137/*Spaghetti Pomodoro Plated*/),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogBun),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.HotdogRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+            (Item) GDOUtils.GetExistingGDO(-823534126/*Spaghetti raw*/)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Steaks/MysterySteakBaseDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakBaseDish.cs
@@ -26,7 +26,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook steak once for rare, twice for medium, and thrice for well-done" }
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Meat\n" + 
+                "Cook steak once for rare, twice for medium, and thrice for well-done" }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
@@ -48,15 +48,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             }
         };
 
-        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new HashSet<Dish.IngredientUnlock>()
-        {
-            new()
-            {
-                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
-                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.RiceContainerCooked)
-            }
-        };
-
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>();
         public override bool RequiresVariant => true;
         public override List<Unlock> HardcodedRequirements => new()

--- a/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 3;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook rice in a wok and add available ingredients (initially only chopped " +
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Rice, <i>up to two variant ingredients per plate</i>\n" + 
+                "Cook rice in a wok and add available ingredients (initially only chopped " +
                 "Carrot or chopped Broccoli) to order. Remember to cook after each ingredient!" }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
@@ -1,19 +1,19 @@
 ﻿using KitchenData;
 using KitchenLib.References;
 using KitchenLib.Utils;
-using KitchenMysteryMenu.Utils;
+using KitchenMysteryMenu.Customs.Dishes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Pies
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
 {
-    public class MysteryPiesBaseDish : GenericMysteryDish
+    public class MysteryStirFryBaseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Pies Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PieBase);
+        protected override string NameTag => "Mystery Stir Fry Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBase);
         public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,18 +22,19 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 2;
+        public override int Difficulty => 3;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Knead flour (or add water) to make dough, then knead into pie crust. Add meat and cook." }
+            { Locale.English, "Cook rice in a wok and add available ingredients (initially only chopped " +
+                "Carrot or chopped Broccoli) to order. Remember to cook after each ingredient!" }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Pies",
-                Description = "Adds meat pie as a main when <b>Flour</b> and <b>Meat</b> are present",
-                FlavourText = "Are you ready for the best pies in PlateUp!?"
+                Name = "Mystery - Stir Fry",
+                Description = "Adds Stir Fry as a main when <b>Rice</b> and one of <b>Carrot</b> or <b>Broccoli</b> are present",
+                FlavourText = "Cook after adding each ingredient!"
             })
         };
 
@@ -41,9 +42,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PiePlated),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
+            }
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new HashSet<Dish.IngredientUnlock>()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.RiceContainerCooked)
             }
         };
 

--- a/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish .cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish .cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFryBroccoliDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Stir Fry Broccoli Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBase);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Chop carrot and add to wok of stir fry ingredients." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry Broccoli",
+                Description = "Adds <b>Broccoli</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            BaseMysteryDish.GameDataObject
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.BroccoliChoppedContainerCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw)
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.StirFry
 {
-    public class MysteryStirFryCarrotDish : GenericMysteryDish
+    public class MysteryStirFryBroccoliDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Stir Fry Carrot Dish";
+        protected override string NameTag => "Mystery Stir Fry Broccoli Dish";
         public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBase);
         public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
@@ -25,15 +25,15 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop carrot and add to wok of stir fry ingredients." }
+            { Locale.English, "Chop broccoli and add to wok of stir fry ingredients." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Stir Fry Carrot",
-                Description = "Adds <b>Carrot</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
-                FlavourText = "Nyehhhh *crunch* What's up, Doc?"
+                Name = "Mystery - Stir Fry Broccoli",
+                Description = "Adds <b>Broccoli</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = ""
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()
@@ -46,12 +46,12 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             new()
             {
                 MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
-                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CarrotChoppedContainerCooked)
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.BroccoliChoppedContainerCooked)
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw)
         };
         public override bool RequiresVariant => false;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();

--- a/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop broccoli and add to wok of stir fry ingredients." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Broccoli\n" + 
+                "Chop broccoli and add to wok of stir fry ingredients." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFryCarrotDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Stir Fry Carrot Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBase);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Chop carrot and add to wok of stir fry ingredients." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry Carrot",
+                Description = "Adds <b>Carrot</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = "Nyehhhh *crunch* What's up, Doc?"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            BaseMysteryDish.GameDataObject
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CarrotChoppedContainerCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot)
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
@@ -25,7 +25,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop carrot and add to wok of stir fry ingredients." }
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Carrot\n" + 
+                "Chop carrot and add to wok of stir fry ingredients." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
@@ -10,9 +10,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.StirFry
 {
-    public class MysteryStirFryBroccoliDish : GenericMysteryDish
+    public class MysteryStirFryRiceDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Stir Fry Broccoli Dish";
+        protected override string NameTag => "Mystery Stir Fry Rice Dish";
         public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBase);
         public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
@@ -25,15 +25,15 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Chop carrot and add to wok of stir fry ingredients." }
+            { Locale.English, "Add rice to wok of stir fry ingredients." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Stir Fry Broccoli",
-                Description = "Adds <b>Broccoli</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
-                FlavourText = ""
+                Name = "Mystery - Stir Fry Rice",
+                Description = "Adds Rice as a <b>REQUIRED</b> ingredient for Stir Fry.",
+                FlavourText = "This card is solely to make Stir Fry work with the Mystery Menu daily selections."
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()
@@ -46,15 +46,14 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             new()
             {
                 MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
-                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.BroccoliChoppedContainerCooked)
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.RiceContainerCooked)
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
-        public override bool RequiresVariant => false;
+        public override bool RequiresVariant => true;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
@@ -25,7 +25,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Add rice to wok of stir fry ingredients." }
+            {
+                Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Rice\n" +
+                "Add rice to wok of stir fry ingredients. **Required to make any stir fry**"
+            }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
@@ -1,0 +1,58 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Turkey
+{
+    public class MysteryTurkeyBaseDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Turkey Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TurkeyBase);
+        public override DishType Type => DishType.Base;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "Cook Turkey when available, then portion, plate, and serve. Portions up to 4 times." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Turkey",
+                Description = "Adds <b>Turkey</b> as a main when it is present",
+                FlavourText = "Gobble gobble gobble!"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.TurkeyPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.TurkeyIngredient)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
@@ -26,7 +26,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         public override int Difficulty => 1;
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "Cook Turkey when available, then portion, plate, and serve. Portions up to 4 times." }
+            { Locale.English, "<color=yellow>Requires ingredient:</color> Turkey\n" + 
+                "Cook Turkey, then portion, plate, and serve. Portions up to 4 times." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {

--- a/Mod.cs
+++ b/Mod.cs
@@ -92,6 +92,7 @@ namespace KitchenMysteryMenu
 
             // Mystery Stir Fry Dishes
             AddGameDataObject<MysteryStirFryBaseDish>();
+            AddGameDataObject<MysteryStirFryRiceDish>();
             AddGameDataObject<MysteryStirFryBroccoliDish>();
             AddGameDataObject<MysteryStirFryCarrotDish>();
 

--- a/Mod.cs
+++ b/Mod.cs
@@ -9,6 +9,7 @@ using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
 using KitchenMysteryMenu.Customs.Dishes.StirFry;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
 using KitchenMysteryMenu.Customs.Ingredients;
 using KitchenMysteryMenu.Customs.ItemGroups;
 using System.Linq;
@@ -93,6 +94,9 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryStirFryBaseDish>();
             AddGameDataObject<MysteryStirFryBroccoliDish>();
             AddGameDataObject<MysteryStirFryCarrotDish>();
+
+            // Mystery Turkey Dishes
+            AddGameDataObject<MysteryTurkeyBaseDish>();
 
             // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -5,6 +5,9 @@ using KitchenMods;
 using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
+using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Fish;
+using KitchenMysteryMenu.Customs.Dishes.HotDog;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
@@ -76,11 +79,18 @@ namespace KitchenMysteryMenu
 
         private void AddDishGDOs()
         {
-            // Mystery Steak Dishes
-            AddGameDataObject<MysterySteakBaseDish>();
-
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
+
+            // Mystery Burger Dishes
+            AddGameDataObject<MysteryBurgerBaseDish>();
+
+            // Mystery Fish Dishes
+            AddGameDataObject<MysteryFishBlueDish>();
+            AddGameDataObject<MysteryFishPinkDish>();
+
+            // Mystery Hot Dog Dishes
+            AddGameDataObject<MysteryHotdogBaseDish>();
 
             // Mystery Pies Dishes
             AddGameDataObject<MysteryPiesBaseDish>();
@@ -89,6 +99,9 @@ namespace KitchenMysteryMenu
             // Mystery Salad Dishes
             AddGameDataObject<MysterySaladBaseDish>();
             AddGameDataObject<MysterySaladTomatoDish>();
+
+            // Mystery Steak Dishes
+            AddGameDataObject<MysterySteakBaseDish>();
 
             // Mystery Stir Fry Dishes
             AddGameDataObject<MysteryStirFryBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -6,10 +6,13 @@ using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Dumplings;
 using KitchenMysteryMenu.Customs.Dishes.Fish;
 using KitchenMysteryMenu.Customs.Dishes.HotDog;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Dishes.Pizza;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
 using KitchenMysteryMenu.Customs.Dishes.StirFry;
 using KitchenMysteryMenu.Customs.Dishes.Turkey;
@@ -85,6 +88,9 @@ namespace KitchenMysteryMenu
             // Mystery Burger Dishes
             AddGameDataObject<MysteryBurgerBaseDish>();
 
+            // Mystery Dumplings Dishes
+            AddGameDataObject<MysteryDumplingsBaseDish>();
+
             // Mystery Fish Dishes
             AddGameDataObject<MysteryFishBlueDish>();
             AddGameDataObject<MysteryFishPinkDish>();
@@ -96,9 +102,15 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryPiesBaseDish>();
             AddGameDataObject<MysteryPiesMeatDish>();
 
+            // Mystery Pizza Dishes
+            AddGameDataObject<MysteryPizzaBaseDish>();
+
             // Mystery Salad Dishes
             AddGameDataObject<MysterySaladBaseDish>();
             AddGameDataObject<MysterySaladTomatoDish>();
+
+            // Mystery Pizza Dishes
+            AddGameDataObject<MysterySpaghettiBaseDish>();
 
             // Mystery Steak Dishes
             AddGameDataObject<MysterySteakBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -6,7 +6,9 @@ using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
 using KitchenMysteryMenu.Customs.Ingredients;
 using KitchenMysteryMenu.Customs.ItemGroups;
 using System.Linq;
@@ -73,12 +75,26 @@ namespace KitchenMysteryMenu
 
         private void AddDishGDOs()
         {
-            // Base Mains
+            // Mystery Steak Dishes
             AddGameDataObject<MysterySteakBaseDish>();
+
+            // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
+
+            // Mystery Pies Dishes
             AddGameDataObject<MysteryPiesBaseDish>();
             AddGameDataObject<MysteryPiesMeatDish>();
 
+            // Mystery Salad Dishes
+            AddGameDataObject<MysterySaladBaseDish>();
+            AddGameDataObject<MysterySaladTomatoDish>();
+
+            // Mystery Stir Fry Dishes
+            AddGameDataObject<MysteryStirFryBaseDish>();
+            AddGameDataObject<MysteryStirFryBroccoliDish>();
+            AddGameDataObject<MysteryStirFryCarrotDish>();
+
+            // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();
         }
     }

--- a/Systems/RemoveMysteryMenuProvidersAtNight.cs
+++ b/Systems/RemoveMysteryMenuProvidersAtNight.cs
@@ -1,4 +1,5 @@
 ﻿using Kitchen;
+using KitchenData;
 using KitchenMysteryMenu.Components;
 using KitchenMysteryMenu.Utils;
 using System;
@@ -39,6 +40,9 @@ namespace KitchenMysteryMenu.Systems
                     // This probably makes more sense when the prefab is set up properly. For now, just do it the same way.
                     var cItemProvider = providerItemProviders[i];
                     cItemProvider.Available = 0;
+                    // Issue #5: empty out the items from the providers so that they can't be used to determine what static ingredients
+                    //      are available or not when new static dish cards are selected. Might want to revert it to the default instead?
+                    cItemProvider.SetAsItem(0);
                     EntityManager.SetComponentData(providerEntities[i], cItemProvider);
                 }
             }

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -462,8 +462,9 @@ namespace KitchenMysteryMenu.Systems
                 }
                 if (IsMenuItem())
                 {
-                    return recipes.Where(r => r.DishOption.MenuItem == MenuItem.Item)
-                        .Any(r => r.CanBeCooked() && (!r.RequiresVariant || r.CanRequiredVariantBeCooked(recipes)));
+                    IEnumerable<MysteryRecipeIngredientCounter> dishOptions = recipes.Where(r => r.DishOption.MenuItem == MenuItem.Item);
+                    return dishOptions.Any(r => !r.RequiresVariant && r.CanBeCooked()) &&
+                        dishOptions.All(r => r.RequiresVariant && r.CanBeCooked() && r.CanRequiredVariantBeCooked(recipes));
                 }
                 // This has a valid DishOption, so check if other Options that aren't the same Ingredient can be cooked.
                 //  (Should hopefully address Rice-only Stir Fry and null reference)
@@ -505,7 +506,7 @@ namespace KitchenMysteryMenu.Systems
                 parentRecipes = GetParentRecipes(nonCurrentRecipes);
                 if (IsMenuItem())
                 {
-                    return CanBeSelected(availableProviderCount);
+                    return CanBeSelected(availableProviderCount) && CanRequiredVariantBeCooked(nonCurrentRecipes);
                 }
                 if (IsAvailableIngredient())
                 {
@@ -541,9 +542,24 @@ namespace KitchenMysteryMenu.Systems
                 return MenuItem.Item != 0;
             }
 
+            public bool IsParentOf(MysteryRecipeIngredientCounter other)
+            {
+                return MenuItem.Item == other.DishOption.MenuItem;
+            }
+
             public bool IsAvailableIngredient()
             {
                 return DishOption.MenuItem != 0 && DishOption.Ingredient != 0;
+            }
+
+            public bool IsChildOf(MysteryRecipeIngredientCounter other)
+            {
+                return DishOption.MenuItem == other.MenuItem.Item;
+            }
+
+            public bool IsSiblingOf(MysteryRecipeIngredientCounter other)
+            {
+                return DishOption.MenuItem == other.DishOption.MenuItem && DishOption.Ingredient != other.DishOption.Ingredient;
             }
         }
     }

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -16,7 +16,7 @@ namespace KitchenMysteryMenu.Systems
 {
     public class SelectMysteryMenuOfDay : StartOfDaySystem
     {
-        private string LogMsgPrefix = "[SelecteMysteryMenuOfDay]";
+        private string LogMsgPrefix = "[SelectMysteryMenuOfDay]";
 
         EntityQuery MysteryItemProviders;
         EntityQuery MenuItems;

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -321,14 +321,15 @@ namespace KitchenMysteryMenu.Systems
                         $"missingIngredients: {{{recipe.MissingIngredientCount}}}");
                     if (recipe.CanBeSelected(numRemainingProviders))
                     {
-                        recipeList.Add(recipe);
                         if (recipe.CanBeServed(currentRecipes))
                         {
+                            recipeList.Add(recipe);
                             found = true;
                             break;
                         }
                         if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, out var parentRecipes))
                         {
+                            recipeList.Add(recipe);
                             recipeList.AddRange(parentRecipes);
                             found = true;
                             break;
@@ -349,6 +350,7 @@ namespace KitchenMysteryMenu.Systems
                 .Sum(e => e.Weight);
             float randomOld = UnityEngine.Random.Range(0f, totalOldWeight);
             float currentOld = 0f;
+            recipeList = new List<MysteryRecipeIngredientCounter>();
 
             Mod.Logger.LogInfo($"{LogMsgPrefix} Searching weight range {{0 -> {totalOldWeight}}} for older recipes. Seeking for {{{randomOld}}}");
             for (int j = 0; j < olderCombinedEntities.Count; j++)
@@ -362,14 +364,15 @@ namespace KitchenMysteryMenu.Systems
                         $"missingIngredients: {{{recipe.MissingIngredientCount}}}");
                     if (recipe.CanBeSelected(numRemainingProviders))
                     {
-                        recipeList.Add(recipe);
                         if (recipe.CanBeServed(currentRecipes))
                         {
+                            recipeList.Add(recipe);
                             found = true;
                             break;
                         }
                         if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, out var parentRecipes))
                         {
+                            recipeList.Add(recipe);
                             recipeList.AddRange(parentRecipes);
                             found = true;
                             break;

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -541,12 +541,13 @@ namespace KitchenMysteryMenu.Systems
                         $"Type = {{{(IsMenuItem() ? "MenuItem" : (IsAvailableIngredient() ? "AvailableIngredient" : "type not found"))}}}");
                     return false;
                 }
-                // If this recipe has no parent recipes (should only be CMenuItem entities), then bypass the rest of the checking.
-                if (parentRecipes.Count() == 0)
+                // If this recipe has no parent recipes and isn't a MenuItem entity, then the parent's card hasn't been selected and isn't available
+                //  for this option/extra.
+                if (parentRecipes.Count() == 0 && !IsMenuItem())
                 {
-                    Mod.Logger.LogInfo($"{logKey} Recipe {{{Recipe.UniqueNameID}}} has no parents. " +
+                    Mod.Logger.LogInfo($"{logKey} Recipe {{{Recipe.UniqueNameID}}} has no valid parents. " +
                         $"Type = {{{(IsMenuItem() ? "MenuItem" : (IsAvailableIngredient() ? "AvailableIngredient" : "type not found"))}}}");
-                    return true;
+                    return false;
                 }
                 // TODO: This might need to handle Side-type MenuItems and ensuring there's a Main already to attach it to, but perhaps
                 //  that'll be handled already by a different process that allots the minimum amount of ingredients applied to each course, thus

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -270,20 +270,19 @@ namespace KitchenMysteryMenu.Systems
             //  If these conditions are met, then consider the entity valid for weighting purposes.
             var availableMenus = currentRecipes.Select(r => r.Recipe).ToList();
             var allValidEntities = allCombinedEntities
-                .Where(e => e.CanBeSelected(numRemainingProviders) && (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities)))
+                .Where(e => e.CanBeSelected(numRemainingProviders) && (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities, currentRecipes)))
                 .ToList();
 
             // Determine what ingredients there are to choose from (i.e. which ingredients are NOT already available)
             Mod.Logger.LogInfo($"{LogMsgPrefix} — Gathering Missing Ingredients");
-            HashSet<Item> missingIngredients = allValidEntities.SelectMany(entity => entity.Recipe.MinimumRequiredMysteryIngredients)
-                .Where(item => !availableItemsForRecipes.Contains(item)).ToHashSet();
+            HashSet<Item> missingIngredients = allValidEntities.SelectMany(entity => entity.MissingIngredients).ToHashSet();
 
             // Loop over ingredients
             foreach (Item item in missingIngredients)
             {
                 // Add the inverse of the count to the total recipe weight such that each *ingredient* only contributes 1.0f
                 //  total weight across all non-current recipes it's in
-                List<MysteryRecipeIngredientCounter> recipesMissingThisItem = allValidEntities.Where(e => e.Recipe.MinimumRequiredMysteryIngredients.Contains(item)).ToList();
+                List<MysteryRecipeIngredientCounter> recipesMissingThisItem = allValidEntities.Where(e => e.MissingIngredients.Contains(item)).ToList();
                 Mod.Logger.LogInfo($"{LogMsgPrefix} — Weight Loop — Unavailable Item {{name = {item.name}}} is in {{{recipesMissingThisItem.Count}}} valid, unlocked recipes");
                 recipesMissingThisItem.ForEach(r => r.Weight += 1f / recipesMissingThisItem.Count);
             }
@@ -296,13 +295,14 @@ namespace KitchenMysteryMenu.Systems
             List<MysteryRecipeIngredientCounter> olderCombinedEntities,
             int numRemainingProviders)
         {
+            var methodPrefix = "SelectRandomRecipe()";
             Mod.Logger.LogInfo($"{LogMsgPrefix} Selecting a random recipe");
             var allCombinedEntities = new List<MysteryRecipeIngredientCounter>();
             allCombinedEntities.AddRange(newerCombinedEntities);
             allCombinedEntities.AddRange(olderCombinedEntities);
             float totalNewWeight = newerCombinedEntities
                 .Where(e => e.CanBeSelected(numRemainingProviders) && 
-                        (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities)))
+                        (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities, currentRecipes)))
                 .Sum(e => e.Weight);
             float randomNew = UnityEngine.Random.Range(0f, totalNewWeight);
             float currentNew = 0f;
@@ -318,23 +318,26 @@ namespace KitchenMysteryMenu.Systems
                 if (randomNew <= currentNew)
                 {
                     Mod.Logger.LogInfo($"{LogMsgPrefix} Found a newer recipe! Name = {{{recipe.Recipe.UniqueNameID}}}; " +
-                        $"missingIngredients: {{{recipe.MissingIngredientCount}}}");
+                        $"missingIngredients: {{{recipe.MissingIngredients.Count}}}");
                     if (recipe.CanBeSelected(numRemainingProviders))
                     {
                         if (recipe.CanBeServed(currentRecipes))
                         {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It can be selected and served alone!");
                             recipeList.Add(recipe);
                             found = true;
                             break;
                         }
-                        if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, out var parentRecipes))
+                        if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, currentRecipes, out var parentRecipes))
                         {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It can be selected and served with {{count = {parentRecipes.Count()}}} parent recipes!");
                             recipeList.Add(recipe);
                             recipeList.AddRange(parentRecipes);
                             found = true;
                             break;
                         }
                     }
+                    Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It cannot be selected or served..?");
                     break;
                 }
             }
@@ -346,7 +349,7 @@ namespace KitchenMysteryMenu.Systems
 
             float totalOldWeight = olderCombinedEntities
                 .Where(e => e.CanBeSelected(numRemainingProviders) &&
-                    (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities)))
+                    (e.CanBeServed(currentRecipes) || e.CouldBeServed(numRemainingProviders, allCombinedEntities, currentRecipes)))
                 .Sum(e => e.Weight);
             float randomOld = UnityEngine.Random.Range(0f, totalOldWeight);
             float currentOld = 0f;
@@ -361,23 +364,26 @@ namespace KitchenMysteryMenu.Systems
                 if (randomOld <= currentOld)
                 {
                     Mod.Logger.LogInfo($"{LogMsgPrefix} Found an older recipe! Name = {{{recipe.Recipe.UniqueNameID}}}; " +
-                        $"missingIngredients: {{{recipe.MissingIngredientCount}}}");
+                        $"missingIngredients: {{{recipe.MissingIngredients.Count}}}");
                     if (recipe.CanBeSelected(numRemainingProviders))
                     {
                         if (recipe.CanBeServed(currentRecipes))
                         {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It can be selected and served alone!");
                             recipeList.Add(recipe);
                             found = true;
                             break;
                         }
-                        if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, out var parentRecipes))
+                        if (recipe.CouldBeServed(numRemainingProviders, allCombinedEntities, currentRecipes, out var parentRecipes))
                         {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It can be selected and served with {{count = {parentRecipes.Count()}}} parent recipes!");
                             recipeList.Add(recipe);
                             recipeList.AddRange(parentRecipes);
                             found = true;
                             break;
                         }
                     }
+                    Mod.Logger.LogInfo($"{LogMsgPrefix} {methodPrefix} - It cannot be selected or served..?");
                     break;
                 }
             }
@@ -418,8 +424,7 @@ namespace KitchenMysteryMenu.Systems
             public CAvailableIngredient DishOption;
             //public CPossibleExtra DishExtra;
             public GenericMysteryDish Recipe;
-            public int NumMatchingIngredients;
-            public int MissingIngredientCount => Recipe.MinimumRequiredMysteryIngredients.Count() - NumMatchingIngredients;
+            public HashSet<Item> MissingIngredients;
             public bool RequiresVariant => Recipe.RequiresVariant;
             public float Weight;
 
@@ -442,7 +447,7 @@ namespace KitchenMysteryMenu.Systems
             {
                 Entity = entity;
                 Recipe = MysteryDishCrossReference.GetMysteryDishById(sourceDishID);
-                NumMatchingIngredients = 0;
+                MissingIngredients = Recipe.MinimumRequiredMysteryIngredients.Select(i => i).ToHashSet();
                 Weight = 0f;
                 MenuItem = menuItem;
                 DishOption = dishOption;
@@ -450,79 +455,128 @@ namespace KitchenMysteryMenu.Systems
 
             public bool CanBeCooked()
             {
-                return Recipe.MinimumRequiredMysteryIngredients.Count <= NumMatchingIngredients;
+                return MissingIngredients.Count == 0;
             }
 
             public bool CanRequiredVariantBeCooked(IEnumerable<MysteryRecipeIngredientCounter> recipes)
             {
+                var logID = "[MRIC.CanRequiredVariantBeCooked()]";
                 if (!RequiresVariant)
                 {
                     // All Extras won't require a variant. Most Options won't require a variant
+                    Mod.Logger.LogInfo($"{logID} - Recipe {{{Recipe.UniqueNameID}}} doesn't require variant, so returning false.");
                     return false;
                 }
                 if (IsMenuItem())
                 {
-                    IEnumerable<MysteryRecipeIngredientCounter> dishOptions = recipes.Where(r => r.DishOption.MenuItem == MenuItem.Item);
-                    return dishOptions.Any(r => !r.RequiresVariant && r.CanBeCooked()) &&
-                        dishOptions.All(r => r.RequiresVariant && r.CanBeCooked() && r.CanRequiredVariantBeCooked(recipes));
+                    IEnumerable<MysteryRecipeIngredientCounter> dishOptions = recipes.Where(r => IsParentOf(r));
+                    bool anyIndependentChildCanBeCooked = dishOptions.Where(r => !r.RequiresVariant).Any(r => r.CanBeCooked());
+                    bool allDependentChildrenCanBeCooked = dishOptions.Where(r => r.RequiresVariant).All(r => r.CanBeCooked() && r.CanRequiredVariantBeCooked(recipes));
+                    Mod.Logger.LogInfo($"{logID} - Recipe {{{Recipe.UniqueNameID}}} is MenuItem. Independent child recipe can be cooked = {{{anyIndependentChildCanBeCooked}}}. " +
+                        $"All dependent children recipes can be cooked = {{{allDependentChildrenCanBeCooked}}}");
+                    return anyIndependentChildCanBeCooked && allDependentChildrenCanBeCooked;
                 }
                 // This has a valid DishOption, so check if other Options that aren't the same Ingredient can be cooked.
                 //  (Should hopefully address Rice-only Stir Fry and null reference)
-                return recipes.Where(r => r.DishOption.MenuItem == DishOption.MenuItem && r.DishOption.Ingredient != DishOption.Ingredient)
-                    .Any(r => r.CanBeCooked());
+                bool anySiblingCanBeCooked = recipes.Where(r => IsSiblingOf(r))
+                                    .Any(r => r.CanBeCooked());
+                Mod.Logger.LogInfo($"{logID} - Recipe {{{Recipe.UniqueNameID}}} is DishOption. Any one sibling recipe can be cooked = {{{anySiblingCanBeCooked}}}");
+                return anySiblingCanBeCooked;
             }
 
             public bool CanBeSelected(int availableProviderCount)
             {
-                return MissingIngredientCount <= availableProviderCount;
+                Mod.Logger.LogInfo($"[MRIC.CanBeSelected()] Recipe = {{{Recipe.UniqueNameID}}}, " +
+                    $"MissingIngredientCount = {{{MissingIngredients.Count}}}, Available Providers = {{{availableProviderCount}}}");
+                return MissingIngredients.Count <= availableProviderCount;
             }
 
             /**
              *  CanBeServed
              *  
-             *  Used to determine if it's serveable given the current recipes.
-             *  When the entity has a CMenuItem, this will essentially always be true.
+             *  Used to determine if it's serveable given the current recipes. Should be true whenever the prereqs are in current, or the dish
+             *      has no prereqs.
+             *  When the entity has a CMenuItem, this will essentially always be true except if it *requires* a variant.
              *  When it's a dish option (CAvailableIngredient or CPossibleExtra), then an already serveable recipe needs to be among the current recipes.
              **/
             public bool CanBeServed(IEnumerable<MysteryRecipeIngredientCounter> currentRecipes)
             {
-                return (IsMenuItem() && !RequiresVariant)
-                    || (IsAvailableIngredient() && currentRecipes.Any(r => r.IsMenuItem() && r.MenuItem.Item == DishOption.MenuItem));
+                var logKey = "[MRIC.CanBeServed()]";
+                var currentRequiresVariantRecipes = currentRecipes.Where(r => r.RequiresVariant);
+                var currentTerminusRecipes = currentRecipes.Where(r => !r.RequiresVariant);
+                if (IsMenuItem())
+                {
+                    bool canMenuItemBeServed = !RequiresVariant ||
+                        currentRecipes.Any(r => r.IsAvailableIngredient() && MenuItem.Item == r.DishOption.MenuItem && !r.RequiresVariant);
+                    Mod.Logger.LogInfo($"{logKey} - MenuItem {{name = {Recipe.UniqueNameID}, requiresVariant = {RequiresVariant}, canBeServed = {canMenuItemBeServed}}}");
+                    return canMenuItemBeServed;
+                }
+
+                bool canOptionBeServed = IsAvailableIngredient() && currentRecipes.Any(r => r.IsMenuItem() && r.MenuItem.Item == DishOption.MenuItem) &&
+                                    (!RequiresVariant || currentRecipes.Any(r => r.IsAvailableIngredient() && !r.RequiresVariant && IsSiblingOf(r)));
+                Mod.Logger.LogInfo($"{logKey} - DishOption {{name = {Recipe.UniqueNameID}, requiresVariant = {RequiresVariant}, canBeServed = {canOptionBeServed}");
+                return canOptionBeServed;
             }
 
             /**
              * CouldBeServed
              * 
-             * When the Recipe can't be served with the current recipes, check to see if it *could* be served if its prerequisite recipe 
-             *  can *also* be selected as a pair.
+             * When the Recipe can't be served with *only* the current recipes, check to see if it *could* be served if non-current prerequisite recipes 
+             *  can *also* be selected as a group.
              */
-            public bool CouldBeServed(int availableProviderCount, IEnumerable<MysteryRecipeIngredientCounter> nonCurrentRecipes)
+            public bool CouldBeServed(int availableProviderCount, IEnumerable<MysteryRecipeIngredientCounter> nonCurrentRecipes, IEnumerable<MysteryRecipeIngredientCounter> currentRecipes)
             {
-                return CouldBeServed(availableProviderCount, nonCurrentRecipes, out _);
+                return CouldBeServed(availableProviderCount, nonCurrentRecipes, currentRecipes, out _);
             }
 
-            public bool CouldBeServed(int availableProviderCount, IEnumerable<MysteryRecipeIngredientCounter> nonCurrentRecipes, out IEnumerable<MysteryRecipeIngredientCounter> parentRecipes)
+            public bool CouldBeServed(int availableProviderCount, IEnumerable<MysteryRecipeIngredientCounter> nonCurrentRecipes, IEnumerable<MysteryRecipeIngredientCounter> currentRecipes, out List<MysteryRecipeIngredientCounter> parentRecipes)
             {
-                parentRecipes = GetParentRecipes(nonCurrentRecipes);
+                var logKey = "[MRIC.CouldBeServed()]";
+                var allUnlockedRecipes = nonCurrentRecipes.Concat(currentRecipes);
+                parentRecipes = GetParentRecipes(allUnlockedRecipes);
+                // If this recipe requires a child variant in order to be served, let the child pull it in instead.
+                if (RequiresVariant)
+                {
+                    Mod.Logger.LogInfo($"{logKey} Recipe {{{Recipe.UniqueNameID}}} requires a variant. " +
+                        $"Type = {{{(IsMenuItem() ? "MenuItem" : (IsAvailableIngredient() ? "AvailableIngredient" : "type not found"))}}}");
+                    return false;
+                }
+                // If this recipe has no parent recipes (should only be CMenuItem entities), then bypass the rest of the checking.
+                if (parentRecipes.Count() == 0)
+                {
+                    Mod.Logger.LogInfo($"{logKey} Recipe {{{Recipe.UniqueNameID}}} has no parents. " +
+                        $"Type = {{{(IsMenuItem() ? "MenuItem" : (IsAvailableIngredient() ? "AvailableIngredient" : "type not found"))}}}");
+                    return true;
+                }
+                // TODO: This might need to handle Side-type MenuItems and ensuring there's a Main already to attach it to, but perhaps
+                //  that'll be handled already by a different process that allots the minimum amount of ingredients applied to each course, thus
+                //  making this block redundant with the above two blocks (RequiresVariant & 0 parents as of 2024-03-19).
                 if (IsMenuItem())
                 {
-                    return CanBeSelected(availableProviderCount) && CanRequiredVariantBeCooked(nonCurrentRecipes);
+                    Mod.Logger.LogInfo($"{logKey} MenuItem {{{Recipe.UniqueNameID}}} - ");
+                    return CanBeSelected(availableProviderCount);
                 }
+                // This is where we ensure that the parent recipes get added and accounted for
                 if (IsAvailableIngredient())
                 {
-                    return CanBeSelected(availableProviderCount - parentRecipes.Sum(r => r.MissingIngredientCount));
+                    int parentMissingIngredientSum = parentRecipes.SelectMany(r => r.MissingIngredients).ToHashSet().Count();
+                    Mod.Logger.LogInfo($"{logKey} AvailableIngredient {{Recipe = {Recipe.UniqueNameID}, MenuItem = " +
+                        $"{Recipe.IngredientsUnlocks.First(iu => iu.Ingredient.ID == DishOption.Ingredient && iu.MenuItem.ID == DishOption.MenuItem).MenuItem.name}," +
+                        $" ParentRecipes = {parentRecipes}, ParentDistinctMissingIngredientSum = {parentMissingIngredientSum}}}");
+                    return CanBeSelected(availableProviderCount - parentMissingIngredientSum);
                 }
+                Mod.Logger.LogInfo($"{logKey} Recipe {{{Recipe.UniqueNameID}}} could not be served. It's not a menu item or available ingredient.");
                 return false;
             }
 
-            public IEnumerable<MysteryRecipeIngredientCounter> GetParentRecipes(IEnumerable<MysteryRecipeIngredientCounter> availableRecipes)
+            public List<MysteryRecipeIngredientCounter> GetParentRecipes(IEnumerable<MysteryRecipeIngredientCounter> availableRecipes)
             {
                 if (IsAvailableIngredient())
                 {
+                    // Menu Item only cares about child relationship, especially once toppings/sauces/extras get involved.
+                    // Siblings are only "parents" if the sibling of this recipe Requires Variant.
                     var parents = availableRecipes
-                        .Where(r => r.RequiresVariant && (
-                            (r.IsMenuItem() && r.MenuItem.Item == DishOption.MenuItem) || 
-                            (r.DishOption.MenuItem == DishOption.MenuItem && r.DishOption.Ingredient != DishOption.Ingredient)))
+                        .Where(r => (r.IsMenuItem() && IsChildOf(r)) || (r.RequiresVariant && IsSiblingOf(r)))
                         .ToList();
                     return parents;
                 }
@@ -534,7 +588,7 @@ namespace KitchenMysteryMenu.Systems
 
             public void RecalculateMatchingCount(HashSet<Item> availableItems)
             {
-                NumMatchingIngredients = Recipe.MinimumRequiredMysteryIngredients.Count(item => availableItems.Any(avaItem => item.ID == avaItem.ID));
+                MissingIngredients.RemoveWhere(i => availableItems.Contains(i));
             }
 
             public bool IsMenuItem()

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -140,6 +140,11 @@ namespace KitchenMysteryMenu.Systems
                 var selectedRecipesIngredients = selectedRecipeList.SelectMany(r => r.Recipe.MinimumRequiredMysteryIngredients).ToHashSet();
                 foreach(var ingredient in selectedRecipesIngredients)
                 {
+                    if (availableItemsForRecipes.Any(item => item.ID == ingredient.ID))
+                    {
+                        // Don't re-add the ingredient if it's already there. 
+                        continue;
+                    }
                     var mysteryProviderCItemProvider = EntityManager.GetComponentData<CItemProvider>(mysteryProviderEntityList[mysteryProviderIndex]);
                     mysteryProviderCItemProvider.SetAsItem(ingredient.ID);
                     EntityManager.SetComponentData(mysteryProviderEntityList[mysteryProviderIndex], mysteryProviderCItemProvider);
@@ -201,7 +206,7 @@ namespace KitchenMysteryMenu.Systems
                 // AvailableIngredients should always be added if they can be cooked, since they still require a MenuItem to be plated.
                 // PossibleExtras should always be added since, if they can be cooked, they were already selected for a provider slot by another option.
                 //      The extra still won't be requested unless its related MenuItem is already there.
-                if (recipe.CanBeCooked() && !recipe.RequiresVariant)
+                if (recipe.CanBeCooked() && (!recipe.IsMenuItem() || !recipe.RequiresVariant))
                 {
                     count++;
                     currentRecipes.Add(recipe);
@@ -475,7 +480,7 @@ namespace KitchenMysteryMenu.Systems
 
             public void RecalculateMatchingCount(HashSet<Item> availableItems)
             {
-                NumMatchingIngredients = Recipe.MinimumRequiredMysteryIngredients.Count(item => availableItems.Contains(item));
+                NumMatchingIngredients = Recipe.MinimumRequiredMysteryIngredients.Count(item => availableItems.Any(avaItem => item.ID == avaItem.ID));
             }
 
             public bool IsMenuItem()


### PR DESCRIPTION
* Adds more details of how Mystery Menu works to the recipe on the Base Mains Card
* Adds "Required Ingredients" text to each Mystery Menu recipe to highlight what to keep an eye out for while playing this mod
* Adds the remaining base mains (as of 2024-03-22) to the Base Mains Card:
    * Turkey
    * Stir Fry
    * Blue & Pink Fish
    * Hot Dogs
    * Burgers
    * Dumplings
    * Spaghetti
    * Pizza