### PR TITLE
Add base main options

### DIFF
--- a/Customs/Appliances/MysteryIngredientProviderExtra.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra2.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra2.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra2 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 2";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra3.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra3.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra3 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 3";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra4.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra4.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra4 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 4";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra5.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra5.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra5 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 5";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra6.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra6.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra6 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 6";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderExtra7.cs
+++ b/Customs/Appliances/MysteryIngredientProviderExtra7.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderExtra7 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Extra 7";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Dishes/Breakfast/MysteryBreakfastBaseDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastBaseDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
             {
                 Name = "Mystery - Breakfast",
                 Description = "Adds toast as a main when <b>Flour</b> is present",
-                FlavourText = "The most important meal of the day"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingBeansDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingBeansDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
+{
+    public class MysteryBreakfastToppingBeansDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Breakfast - Beans";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BreakfastBeans);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Beans\n" + 
+                "Put uncooked beans in a pot and cook. Plate with  <i>Breakfast</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Breakfast - Beans",
+                Description = "Adds Beans as a topping for Breakfast",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BreakfastPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.BeansServing)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BeansIngredient),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingEggsDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingEggsDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
+{
+    public class MysteryBreakfastToppingEggsDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Breakfast - Eggs";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BreakfastExtras);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Egg\n" + 
+                "Crack egg and cook. Plate with  <i>Breakfast</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Breakfast - Eggs",
+                Description = "Adds Eggs as a topping for Breakfast",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BreakfastPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.EggCooked)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingMushroomDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingMushroomDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
+{
+    public class MysteryBreakfastToppingMushroomDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Breakfast - Mushroom";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BreakfastVeganExtras);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Mushroom\n" + 
+                "Chop a mushroom. Plate with  <i>Breakfast</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Breakfast - Mushroom",
+                Description = "Adds Mushrooms as a topping for Breakfast",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BreakfastPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingTomatoDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingTomatoDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
+{
+    public class MysteryBreakfastToppingTomatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Breakfast - Tomato";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BreakfastVeganExtras);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Tomato\n" + 
+                "Chop tomato once. Plate with  <i>Breakfast</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Breakfast - Tomato",
+                Description = "Adds Tomato as a topping for Breakfast",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BreakfastPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerBaseDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Burger
             {
                 Name = "Mystery - Burger",
                 Description = "Adds burgers as a main when <b>Burger Bun</b> and <b>Burger Patty</b> are present",
-                FlavourText = "Bah dap bap bap baaah!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Burger/MysteryBurgerToppingCheeseDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingCheeseDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Burger
+{
+    public class MysteryBurgerToppingCheeseDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Burger - Cheese";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BurgerCheese);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Cheese\n" + 
+                "Chop cheese. Plate with  <i>Burger</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Burger - Cheese",
+                Description = "Adds Cheese as a topping for Burgers",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BurgerPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CheeseGrated)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Burger/MysteryBurgerToppingOnionDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingOnionDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Burger
+{
+    public class MysteryBurgerToppingOnionDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Burger - Onion";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BurgerTomatoandOnion);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Onion\n" + 
+                "Chop onion. Plate with  <i>Burger</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Burger - Onion",
+                Description = "Adds Onion as a topping for Burgers",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BurgerPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.OnionChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Burger/MysteryBurgerToppingTomatoDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingTomatoDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Burger
+{
+    public class MysteryBurgerToppingTomatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Burger - Tomato";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BurgerTomatoandOnion);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Tomato\n" + 
+                "Chop tomato once. Plate with  <i>Burger</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Burger - Tomato",
+                Description = "Adds Tomato as a topping for Burgers",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BurgerPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Dumplings/MysteryDumplingsBaseDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsBaseDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
             {
                 Name = "Mystery - Dumplings",
                 Description = "Adds dumplings as a main when <b>Flour</b>, <b>Meat</b>, and <b>Carrots</b> are present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSeaweedDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSeaweedDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
+{
+    public class MysteryDumplingsSeaweedDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Dumplings - Seaweed";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.DumplingsSeaweed);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Seaweed\n" + 
+                "Cook seaweed. Plate with  <i>Dumplings</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dumplings - Seaweed",
+                Description = "Adds Seaweed as a topping for Dumplings",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.DumplingsPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SeaweedCooked)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Seaweed),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
             {
                 Name = "Mystery - Dumplings - Soy Sauce",
                 Description = "Adds Soy Sauce as a possible extra after serving Dumplings.",
-                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
+{
+    public class MysteryDumplingsSoySauceDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Dumplings - Soy Sauce";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.DumplingSoySauce);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Soy Sauce\n" + 
+                "After serving a  <i>Dumplings</i>, customers may request Soy Sauce as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dumplings - Soy Sauce",
+                Description = "Adds Soy Sauce as a possible extra after serving Dumplings.",
+                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.DumplingsPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CondimentSoySauce)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CondimentSoySauce),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
+        };
+        public override bool RequiresVariant => true;
+    }
+}

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
@@ -55,6 +55,5 @@ namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
-        public override bool RequiresVariant => true;
     }
 }

--- a/Customs/Dishes/Fish/MysteryFishBlueDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishBlueDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery Fish - Blue",
                 Description = "Adds <b>Blue Fish</b> as a main when it is present",
-                FlavourText = "Just keep swimming!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Fish/MysteryFishCrabCakeDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishCrabCakeDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery - Fish - Crab Cakes",
                 Description = "Adds <b>Crab Cake</b> as a main when Crabs, Eggs, and Flour are present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Fish/MysteryFishCrabCakeDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishCrabCakeDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishCrabCakeDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Crab Cake Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishCrabCake);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Crab, Egg, Flour\n" + 
+                "Chop crab. Crack an egg and combine with the crab. Finally, combine with flour, then cook." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Fish - Crab Cakes",
+                Description = "Adds <b>Crab Cake</b> as a main when Crabs, Eggs, and Flour are present",
+                FlavourText = ""
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CrabCakePlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CrabRaw),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Fish/MysteryFishFilletDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishFilletDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery - Fish - Fillets",
                 Description = "Adds <b>Fish Fillet</b> as a main when it is present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Fish/MysteryFishFilletDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishFilletDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishFilletDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Fillet Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishFillet);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Fish Fillet\n" + 
+                "Chop fish to make fillet, then cook, plate, and serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Fish - Fillets",
+                Description = "Adds <b>Fish Fillet</b> as a main when it is present",
+                FlavourText = ""
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishFilletPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishFilletRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Fish/MysteryFishOysterDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishOysterDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishOysterDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Oyster Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishOyster);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Oysters\n" + 
+                "Shuck (chop) 2-3 oysters per plate, then serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Fish - Oyster",
+                Description = "Adds <b>Oysters</b> as a main when it is present",
+                FlavourText = "Serve 2-3 Oysters per plate"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishOysterPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishOysterRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Fish/MysteryFishOysterDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishOysterDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery - Fish - Oyster",
                 Description = "Adds <b>Oysters</b> as a main when it is present",
-                FlavourText = "Serve 2-3 Oysters per plate"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Fish/MysteryFishPinkDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishPinkDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery - Fish - Pink",
                 Description = "Adds <b>Pink Fish</b> as a main when it is present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Fish/MysteryFishSpinyDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishSpinyDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Fish
+{
+    public class MysteryFishSpinyDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Fish Spiny Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.FishSpiny);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 1;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Spiny Fish\n" + 
+                "Portion the spines from the fish, then cook, plate, and serve." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Fish - Spiny Fish",
+                Description = "Adds <b>Spiny Fish</b> as a main when it is present",
+                FlavourText = ""
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.FishSpinyPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.FishSpinyRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Fish/MysteryFishSpinyDish.cs
+++ b/Customs/Dishes/Fish/MysteryFishSpinyDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Fish
             {
                 Name = "Mystery - Fish - Spiny Fish",
                 Description = "Adds <b>Spiny Fish</b> as a main when it is present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/GenericMysteryDish.cs
+++ b/Customs/Dishes/GenericMysteryDish.cs
@@ -15,11 +15,13 @@ namespace KitchenMysteryMenu.Customs.Dishes
         // Make sure OrigDish is a unique ID
         public abstract Dish OrigDish { get; }
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
-        public override string UniqueNameID => "Mystery : " + NameTag;
+        public override string UniqueNameID => "Mystery Dish: " + NameTag;
         public override bool IsUnlockable => false;
         public override bool IsAvailableAsLobbyOption => false;
 
         public abstract HashSet<Item> MinimumRequiredMysteryIngredients { get; }
+
+        public override HashSet<Process> RequiredProcesses => OrigDish.RequiredProcesses;
         /**
          * RequiresVariant
          * Override as true if the base dish is not enough to be ordered on its own. Especially useful for plated dishes

--- a/Customs/Dishes/GenericMysteryDishCard.cs
+++ b/Customs/Dishes/GenericMysteryDishCard.cs
@@ -12,7 +12,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
     public abstract class GenericMysteryDishCard : CustomDish
     {
         protected abstract string NameTag { get; }
-        public override string UniqueNameID => "Mystery Menu Card : " + NameTag;
+        public override string UniqueNameID => "Mystery Card: " + NameTag;
         public abstract HashSet<GenericMysteryDish> ContainedMysteryRecipes { get; }
         public override List<Dish.MenuItem> ResultingMenuItems => 
             ContainedMysteryRecipes.SelectMany(r => r.ResultingMenuItems).ToList();

--- a/Customs/Dishes/HotDog/MysteryHotDogBaseDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotDogBaseDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
             {
                 Name = "Mystery - Hot Dog",
                 Description = "Adds hot dogs as a main when <b>Hot Dog Buns</b> and <b>Hot Dog Links</b> are present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
             {
                 Name = "Mystery - Hot Dog - Extra Ketchup",
                 Description = "Adds Ketchup as a possible extra after serving a Hot Dog.",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()

--- a/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
@@ -55,6 +55,5 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
-        public override bool RequiresVariant => true;
     }
 }

--- a/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+{
+    public class MysteryHotdogKetchupDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Hot Dog Ketchup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogBase);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Ketchup\n" + 
+                "After serving a  <i>Hot Dog</i>, customers may request Ketchup as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Hot Dog - Extra Ketchup",
+                Description = "Adds Ketchup as a possible extra after serving a Hot Dog.",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.HotdogPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CondimentKetchup)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CondimentKetchup),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
+        };
+        public override bool RequiresVariant => true;
+    }
+}

--- a/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.HotDog
+{
+    public class MysteryHotdogMustardDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Hot Dog Mustard";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.HotdogCondimentMustard);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Mustard\n" + 
+                "After serving a  <i>Hot Dog</i>, customers may request Mustard as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Hot Dog - Extra Mustard",
+                Description = "Adds Mustard as a possible extra after serving a Hot Dog.",
+                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.HotdogPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CondimentMustard)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CondimentMustard),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
+        };
+        public override bool RequiresVariant => true;
+    }
+}

--- a/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
             {
                 Name = "Mystery - Hot Dog - Extra Mustard",
                 Description = "Adds Mustard as a possible extra after serving a Hot Dog.",
-                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()

--- a/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
@@ -55,6 +55,5 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
-        public override bool RequiresVariant => true;
     }
 }

--- a/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
@@ -1,0 +1,78 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Fish;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuCarnivoreVariationsDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Carnivorous Variety";
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Large;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryMeat>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of every steak variant
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakThinDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakThickDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBonedDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishCrabCakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishFilletDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishOysterDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishSpinyDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFrySteakDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=cyan>New possible menu items:</color> Thin-Cut Steak, Thick-Cut Steak, Bone-In Steak, " +
+                "Spiny Fish, Oysters, Fish Fillet, Crab Cakes, Steak Stir Fry\n" +
+                "Adds one extra Mystery Provider."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Carnivorous Variations",
+                Description = "Adds Thin Steak, Thick Steak, Bone-in Steak, Spiny Fish, Fish Fillet, Oysters, Crab Cakes, " +
+                "and Steak Stir Fry as possible Mains. Provides one additional Mystery Ingredient Provider.",
+                FlavourText = "Also known as: Surf & Turf"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
@@ -22,7 +22,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         protected override string NameTag => "Carnivorous Variety";
         public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
-        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Large;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
         public override bool IsUnlockable => true;
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
@@ -32,7 +32,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public override HashSet<Item> MinimumIngredients => new()
         {
             // Add X Mystery Ingredients
-            GDOUtils.GetCastedGDO<Item, MysteryMeat>(),
+            GDOUtils.GetCastedGDO<Item, MysterySurfNTurf>(),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
         };
         public override HashSet<Process> RequiredProcesses => new()
@@ -42,20 +42,22 @@ namespace KitchenMysteryMenu.Customs.Dishes
 
         public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
         {
-            // Add the Mystery versions of every steak variant
+            // Add the Mystery versions of every steak & fish variant plus steak stir fry
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakThinDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakThickDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBonedDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishCrabCakeDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishFilletDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishOysterDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryFishSpinyDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFrySteakDish>(),
         };
 
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "<color=cyan>New possible menu items:</color> Thin-Cut Steak, Thick-Cut Steak, Bone-In Steak, " +
+            { Locale.English, "<color=#00ffff>New possible menu items:</color> Thin-Cut Steak, Thick-Cut Steak, Bone-In Steak, " +
                 "Spiny Fish, Oysters, Fish Fillet, Crab Cakes, Steak Stir Fry\n" +
                 "Adds one extra Mystery Provider."
             }

--- a/Customs/Dishes/MysteryMenuCondimentsDish.cs
+++ b/Customs/Dishes/MysteryMenuCondimentsDish.cs
@@ -55,7 +55,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Hot Dogs</i> - Extra Ketchup, Extra Mustard;  " +
                 "<i>Dumplings</i> - Soy Sauce;  <i>Stir Fry</i> - Soy Sauce\n" +
-                "Adds two extra Mystery Providers."
+                "Adds one extra Mystery Provider."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/MysteryMenuCondimentsDish.cs
+++ b/Customs/Dishes/MysteryMenuCondimentsDish.cs
@@ -1,0 +1,77 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.HotDog;
+using KitchenMysteryMenu.Customs.Dishes.Dumplings;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuCondimentsDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Condiments";
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysterySoySauce>(),
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of every condiment
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogKetchupDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogMustardDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryDumplingsSoySauceDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFrySoySauceDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Hot Dogs</i> - Extra Ketchup, Extra Mustard;  " +
+                "<i>Dumplings</i> - Soy Sauce;  <i>Stir Fry</i> - Soy Sauce\n" +
+                "Adds two extra Mystery Providers."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Condiments",
+                Description = "Adds Ketchup and Mustard as possible condiments that customers may request after receiving " +
+                "Hot Dogs, and Soy Sauce as a possible condiment for both Dumplings and Stir Fry.\n" +
+                "Provides one additional Mystery Ingredient Provider.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuSaucesDish.cs
+++ b/Customs/Dishes/MysteryMenuSaucesDish.cs
@@ -1,0 +1,83 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuSaucesDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Sauces";
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 4;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryOnion>(),
+            GDOUtils.GetCastedGDO<Item, MysteryWine>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Water)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of every sauce
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceMushroomSauceDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceRedWineJusDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyCranberrySauceDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyGravyDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySpaghettiBologneseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySpaghettiCheesyDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Any Steak</i> - Mushroom Sauce" +
+                ", Red Wine Jus;  <i>Turkey</i> - Gravy, Cranberry Sauce;  <i>Spaghetti</i> - Bolognese, Cheesy Spaghetti\n" +
+                "Adds two extra Mystery Providers."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Sauces",
+                Description = "Adds Mushroom Sauce and Red Wine Jus as possible Extras for Steaks, Gravy and Cranberry Sauce " +
+                "as possible Extras for Turkey, and Bolognese Sauce and Cheesy Spaghetti as alternative Mains with Spaghetti.\n" +
+                "Provides two additional Mystery Ingredient Providers.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuToppingsDish.cs
+++ b/Customs/Dishes/MysteryMenuToppingsDish.cs
@@ -1,0 +1,98 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Salad;
+using KitchenMysteryMenu.Customs.Dishes.Pizza;
+using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Dumplings;
+using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Breakfast;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuToppingsDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Toppings";
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 4;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryMushroom>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of every veggie-like variant
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastToppingBeansDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastToppingEggsDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastToppingMushroomDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastToppingTomatoDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerToppingCheeseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerToppingOnionDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerToppingTomatoDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryDumplingsSeaweedDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladToppingOnionDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladToppingOliveDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakToppingMushroomDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakToppingTomatoDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyStuffingDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color> Breakfast - Beans, Eggs, Tomato, Mushroom;" +
+                " Burger - Cheese, Tomato, Onion; Dumplings - Seaweed; Salad - Onion, Olives; Turkey - Stuffing\n" +
+                "Adds one extra Mystery Provider."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Toppings",
+                Description = "Adds Beans, Eggs, Tomato, and Mushroom as possible Breakfast toppings; Cheese, Tomato, " +
+                "and Onion as possible Burger toppings; Mushroom and Tomato as possible Steak toppings; Seaweed as a " +
+                "possible topping for Dumplings; Onion and Olives as possible Salad toppings; and Stuffing as a possible " +
+                "Turkey topping.\n" +
+                "Provides one additional Mystery Ingredient Provider.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuVeggieVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuVeggieVariationsDish.cs
@@ -1,0 +1,88 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Salad;
+using KitchenMysteryMenu.Customs.Dishes.Pizza;
+using KitchenMysteryMenu.Customs.Dishes.Pies;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Dishes.StirFry;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuVeggieVariationsDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Vegetarian Variety";
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Large;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 4;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryApple>(),
+            GDOUtils.GetCastedGDO<Item, MysteryMushroom>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of every veggie-like variant
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesMushroomDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPiesVegetableDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPizzaMushroomDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPizzaOnionDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladAppleDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladPotatoDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBambooDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryMushroomDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryNutRoastDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color> Apple Salad, Potato Salad, Mushroom Pie, " +
+                "Veggie Pie, Nut Roast, Onion Pizza, Mushroom Pizza, Bamboo Stir Fry, Mushroom Stir Fry\n" +
+                "Adds two extra Mystery Providers."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Vegetarian Variations",
+                Description = "Adds Apple Salad, Potato Salad, Mushroom Pie, Veggie Pie, Nut Roast, Onion Pizza, Mushroom Pizza, Bamboo " +
+                "Stir Fry, and Mushroom Stir Fry as possible Mains.\n" +
+                "Provides two additional Mystery Ingredient Providers.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Pies/MysteryPiesBaseDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesBaseDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
             {
                 Name = "Mystery - Pies",
                 Description = "Adds meat pie as a main when <b>Flour</b> and <b>Meat</b> are present",
-                FlavourText = "Are you ready for the best pies in PlateUp!?"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Pies/MysteryPiesMeatDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesMeatDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pies
             {
                 Name = "Mystery - Meat Pies",
                 Description = "Adds meat pie as a main when <b>Flour</b> and <b>Meat</b> are present",
-                FlavourText = "Are you ready for the best pies in PlateUp!?"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()

--- a/Customs/Dishes/Pies/MysteryPiesMushroomDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesMushroomDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Pies
+{
+    public class MysteryPiesMushroomDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Pies - Mushroom";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PieMushroom);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Mushroom\n" + 
+                "Knead flour (or add water) to make dough, then knead into pie crust. Add mushroom, then cook." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Pies - Mushroom",
+                Description = "Adds mushroom pie as a main when <b>Flour</b> and <b>Mushroom</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.PiePlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.PieMushroomCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>();
+    }
+}

--- a/Customs/Dishes/Pies/MysteryPiesVegetableDish.cs
+++ b/Customs/Dishes/Pies/MysteryPiesVegetableDish.cs
@@ -1,0 +1,63 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Pies
+{
+    public class MysteryPiesVegetableDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Pies - Vegetable";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PieVegetable);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Carrot, Broccoli\n" + 
+                "Knead flour (or add water) to make dough, then knead into pie crust. Add carrots and broccoli, then cook." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Pies - Vegetable",
+                Description = "Adds vegetable pie as a main when <b>Flour</b>, <b>Carrots</b>, and <b>Broccoli</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.PiePlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.PieVegetableCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryPiesBaseDish>();
+    }
+}

--- a/Customs/Dishes/Pizza/MysteryPizzaBaseDish.cs
+++ b/Customs/Dishes/Pizza/MysteryPizzaBaseDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Pizza
             {
                 Name = "Mystery - Pizza",
                 Description = "Adds pizzas as a main when <b>Flour</b>, <b>Oil</b>, <b>Tomato</b>, and <b>Cheese</b> are present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Pizza/MysteryPizzaMushroomDish.cs
+++ b/Customs/Dishes/Pizza/MysteryPizzaMushroomDish.cs
@@ -1,0 +1,69 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Pizza
+{
+    public class MysteryPizzaMushroomDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Pizza - Mushroom";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PizzaMushroom);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Tomato, Cheese, Oil, Mushroom\n" +
+                "Knead (or add water to) flour to make dough, then combine with oil to make Pizza Crust. " +
+                "Chop a tomato twice to make tomato sauce. Chop cheese. Chop mushroom.\n" +
+                "Combine the pizza crust with the sauce, cheese, and mushroom, then cook. Portions 4 slices."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Pizza - Mushroom",
+                Description = "Adds mushroom pizza as a main when <b>Flour</b>, <b>Oil</b>, <b>Tomato</b>, " +
+                    "<b>Cheese</b>, and <b>Mushroom</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.PizzaPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomCookedWrapped)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Oil),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryPizzaBaseDish>();
+    }
+}

--- a/Customs/Dishes/Pizza/MysteryPizzaOnionDish.cs
+++ b/Customs/Dishes/Pizza/MysteryPizzaOnionDish.cs
@@ -1,0 +1,69 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Pizza
+{
+    public class MysteryPizzaOnionDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Pizza - Onion";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PizzaOnion);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Flour, Tomato, Cheese, Oil, Onion\n" +
+                "Knead (or add water to) flour to make dough, then combine with oil to make Pizza Crust. " +
+                "Chop a tomato twice to make tomato sauce. Chop cheese. Chop onion.\n" +
+                "Combine the pizza crust with the sauce, cheese, and onion, then cook. Portions 4 slices."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Pizza - Mushroom",
+                Description = "Adds mushroom pizza as a main when <b>Flour</b>, <b>Oil</b>, <b>Tomato</b>, " +
+                    "<b>Cheese</b>, and <b>Onion</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.PizzaPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.OnionCookedWrapped)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Oil),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override bool RequiresVariant => false;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryPizzaBaseDish>();
+    }
+}

--- a/Customs/Dishes/Salad/MysterySaladAppleDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladAppleDish.cs
@@ -1,0 +1,65 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Salad
+{
+    public class MysterySaladAppleDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Salad - Apple Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SaladApple);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Lettuce, Apple, Egg, Oil, Nuts\n" +
+                "Chop lettuce. Chop an apple. Crack an egg, combine it with oil to make mayonnaise.\n" +
+                "Combine the lettuce, apple, mayo, and nuts onto a plate." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Apple Salad",
+                Description = "Adds apple salad as a main when <b>Lettuce</b>, <b>Apples</b>, <b>Eggs</b>, <b>Oil</b>, and <b>Nuts</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.SaladApplePlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Lettuce),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Apple),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Oil),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.NutsIngredient),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Salad/MysterySaladBaseDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladBaseDish.cs
@@ -35,8 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
             {
                 Name = "Mystery - Salad",
                 Description = "Adds salad as a main dish when <b>Lettuce</b> is present",
-                FlavourText = "No cooking, but lots of chopping!\n" +
-                            "Basic lettuce salads. If <b>Tomato</b> is present, serve salads with and without chopped tomato."
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Salad/MysterySaladPotatoDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladPotatoDish.cs
@@ -1,0 +1,64 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Salad
+{
+    public class MysterySaladPotatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Salad - Potato Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SaladPotato);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 4;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Potato, Egg, Oil, Onion\n" +
+                "Chop potato, add to a pot with water and boil. Crack an egg, combine it with oil to make mayonnaise.\n" +
+                "Chop an onion, then combine the boiled chopped potato, mayo, and onion onto a plate." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Potato Salad",
+                Description = "Adds potato salad as a main when <b>Potato</b>, <b>Eggs</b>, <b>Oil</b>, and <b>Onions</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.SaladPotatoPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Potato),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Oil),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Salad/MysterySaladTomatoDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladTomatoDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
             {
                 Name = "Mystery Salad - Tomato Topping",
                 Description = "Adds chopped tomato as a topping option when <b>Tomato</b> is present",
-                FlavourText = "Serve salads with and without chopped tomato."
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()

--- a/Customs/Dishes/Salad/MysterySaladToppingOliveDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladToppingOliveDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Salad
+{
+    public class MysterySaladToppingOliveDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Salad - Olive Topping";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SaladToppings);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Olive\n" + 
+                "Take olive and combine with  <i>Salad</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Salad Topping - Olives",
+                Description = "Adds Olives as a topping for Salads",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SaladPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Olive)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Olive),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Salad/MysterySaladToppingOnionDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladToppingOnionDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Salad
+{
+    public class MysterySaladToppingOnionDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Salad - Onion Topping";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SaladToppings);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Onion\n" + 
+                "Chop onion once, then plate with  <i>Salad</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Salad Topping - Onion",
+                Description = "Adds Onion as a topping for Salads",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SaladPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.OnionChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBaseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBaseDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
             {
                 Name = "Mystery - Spaghetti",
                 Description = "Adds spaghetti as a main when <b>Tomatoes</b> and <b>Raw Spaghetti</b> are present",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
@@ -10,11 +10,11 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
 {
-    public class MysterySpaghettiBaseDish : GenericMysteryDish
+    public class MysterySpaghettiBologneseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Spaghetti Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(References.SpaghettiBaseDish);
-        public override DishType Type => DishType.Base;
+        protected override string NameTag => "Mystery Spaghetti Bolognese Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(References.SpaghettiBologneseDish);
+        public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
@@ -22,21 +22,22 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 2;
+        public override int Difficulty => 3;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Tomato, Spaghetti\n" +
+                "<color=yellow>Requires ingredients:</color> Tomato, Spaghetti, Mince\n" +
                 "Put raw spaghetti into a pot with water and boil, then empty the water into the trash. " +
-                "Chop tomato twice to make sauce. Combine boiled pasta on a plate with the sauce." }
+                "Cook mince. Chop tomato twice to make sauce. Combine cooked mince and tomato sauce in a pot, then cook. " +
+                "Combine boiled pasta on a plate with the pot of sauce." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Spaghetti",
-                Description = "Adds spaghetti as a main when <b>Tomatoes</b> and <b>Raw Spaghetti</b> are present",
-                FlavourText = ""
+                Name = "Mystery - Spaghetti Bolognese",
+                Description = "Adds spaghetti bolognese as a main when <b>Tomatoes</b>, <b>Mince</b>, and <b>Raw Spaghetti</b> are present",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
             })
         };
 
@@ -44,7 +45,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(References.SpaghettiPomodoroPlated/*Spaghetti Pomodoro Plated*/),
+                Item = (Item)GDOUtils.GetExistingGDO(References.SpaghettiBolognesePlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
@@ -52,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
-            (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw)
+            (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw),
+            (Item) GDOUtils.GetExistingGDO(References.MinceRaw)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
@@ -54,11 +54,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
             (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw),
-            (Item) GDOUtils.GetExistingGDO(References.MinceRaw)
+            (Item) GDOUtils.GetExistingGDO(References.Mince)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
     }
 }

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
             {
                 Name = "Mystery - Spaghetti Bolognese",
                 Description = "Adds spaghetti bolognese as a main when <b>Tomatoes</b>, <b>Mince</b>, and <b>Raw Spaghetti</b> are present",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
@@ -10,11 +10,11 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
 {
-    public class MysterySpaghettiBaseDish : GenericMysteryDish
+    public class MysterySpaghettiCheesyDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Spaghetti Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(References.SpaghettiBaseDish);
-        public override DishType Type => DishType.Base;
+        protected override string NameTag => "Mystery Spaghetti Cheesy Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(References.SpaghettiCheesyDish);
+        public override DishType Type => DishType.Main;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
@@ -22,21 +22,22 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
         public override bool RequiredNoDishItem => false;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 2;
+        public override int Difficulty => 3;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Tomato, Spaghetti\n" +
-                "Put raw spaghetti into a pot with water and boil, then empty the water into the trash. " +
-                "Chop tomato twice to make sauce. Combine boiled pasta on a plate with the sauce." }
+                "<color=yellow>Requires ingredients:</color> Spaghetti, Butter, Flour, Milk, Cheese\n" +
+                "Put raw spaghetti into a pot with water and boil, then empty the water into the trash.\n" +
+                "Add butter and flour to a pot and cook. Add milk and mix, then add more milk and mix again.\n" +
+                "Combine boiled pasta on a plate with the sauce. Chop cheese and add." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Spaghetti",
-                Description = "Adds spaghetti as a main when <b>Tomatoes</b> and <b>Raw Spaghetti</b> are present",
-                FlavourText = ""
+                Name = "Mystery - Cheesy Spaghetti",
+                Description = "Adds cheesy spaghetti as a main when <b>Cheese</b>, <b>Butter</b>, <b>Flour</b>, <b>Milk</b>, and <b>Raw Spaghetti</b> are present",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
             })
         };
 
@@ -44,15 +45,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(References.SpaghettiPomodoroPlated/*Spaghetti Pomodoro Plated*/),
+                Item = (Item)GDOUtils.GetExistingGDO(References.SpaghettiCheesyPlated),
                 Phase = MenuPhase.Main,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
-            (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw),
+            (Item) GDOUtils.GetExistingGDO(References.Butter)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
             {
                 Name = "Mystery - Spaghetti with Cheese",
                 Description = "Adds cheesy spaghetti as a main when <b>Cheese</b>, <b>Butter</b>, <b>Flour</b>, <b>Milk</b>, and <b>Raw Spaghetti</b> are present",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cheesy Spaghetti",
+                Name = "Mystery - Spaghetti with Cheese",
                 Description = "Adds cheesy spaghetti as a main when <b>Cheese</b>, <b>Butter</b>, <b>Flour</b>, <b>Milk</b>, and <b>Raw Spaghetti</b> are present",
                 FlavourText = "(placeholder card, do not add with Cards Manager)"
             })
@@ -60,7 +60,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakBaseDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakBaseDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Steak",
                 Description = "Adds steak as a main when <b>Meat</b> is present",
-                FlavourText = "Cook steaks multiple times to match the order"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Steaks/MysterySteakBonedDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakBonedDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakBonedDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Boned Steak Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BonedSteaks);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Bone-In Meat\n" + 
+                "Cook steak once for rare, twice for medium, and thrice for well-done. " +
+                "After the customer is done, portion off and trash the bone before washing the plate." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Bone-In Steak",
+                Description = "Adds Bone-In steak as a main when <b>Bone-In Meat</b> is present",
+                FlavourText = "Be sure to trash the bone when they're done!"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.BonedSteakPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.MeatBoned)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakBonedDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakBonedDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Bone-In Steak",
                 Description = "Adds Bone-In steak as a main when <b>Bone-In Meat</b> is present",
-                FlavourText = "Be sure to trash the bone when they're done!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Steak Sauce - Mushroom Sauce",
                 Description = "Adds Mushroom Sauce as an option for any Steak dish",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()

--- a/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
@@ -1,0 +1,76 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakSauceMushroomSauceDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Steak - Mushroom Sauce Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SteakSauceMushroomSauce);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Onion, Mushroom\n" + 
+                "Cook onion in a pot of water to make broth. Chop a mushroom, add to the broth and cook again.\n" +
+                "Plate with any  <i>Steak</i> dish." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Steak Sauce - Mushroom Sauce",
+                Description = "Adds Mushroom Sauce as an option for any Steak dish",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceMushroomPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BonedSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceMushroomPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThickSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceMushroomPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThinSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceMushroomPortion)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
@@ -1,0 +1,76 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakSauceRedWineJusDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Steak - Red Wine Jus Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SteakSauceRedWineJus);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Onion, Wine Bottle\n" + 
+                "Cook onion in a pot of water to make broth. Add red wine to the broth and cook again. " +
+                "Plate with any  <i>Steak</i> dish." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Steak Sauce - Red Wine Jus",
+                Description = "Adds Red Wine Jus as a sauce option for any Steak dish",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceRedPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BonedSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceRedPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThickSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceRedPortion)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThinSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.SauceRedPortion)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.WineBottle),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Steak Sauce - Red Wine Jus",
                 Description = "Adds Red Wine Jus as a sauce option for any Steak dish",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()

--- a/Customs/Dishes/Steaks/MysterySteakThickDish .cs
+++ b/Customs/Dishes/Steaks/MysterySteakThickDish .cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Thick-Cut Steak",
                 Description = "Adds Thick-Cut steak as a main when <b>Thick Meat</b> is present",
-                FlavourText = "Be mindful, they take a long time to cook!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Steaks/MysterySteakThickDish .cs
+++ b/Customs/Dishes/Steaks/MysterySteakThickDish .cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakThickDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Thick Steak Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.ThickSteaks);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Thick Meat\n" + 
+                "Cook steak once for rare, twice for medium, and thrice for well-done. " +
+                "Cooks and burns far slower than regular Meat" }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Thick-Cut Steak",
+                Description = "Adds Thick-Cut steak as a main when <b>Thick Meat</b> is present",
+                FlavourText = "Be mindful, they take a long time to cook!"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ThickSteakPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.MeatThick)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakThinDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakThinDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakThinDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Thin Steak Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.ThinSteaks);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Thin Meat\n" + 
+                "Cook steak once for rare, twice for medium, and thrice for well-done. " +
+                "Cooks and burns faster than regular Meat" }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Thin-Cut Steak",
+                Description = "Adds Thin-Cut steak as a main when <b>Thin Meat</b> is present",
+                FlavourText = "Be careful, they cook fast!"
+            })
+        };
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ThinSteakPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.MeatThin)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakThinDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakThinDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
             {
                 Name = "Mystery - Thin-Cut Steak",
                 Description = "Adds Thin-Cut steak as a main when <b>Thin Meat</b> is present",
-                FlavourText = "Be careful, they cook fast!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Steaks/MysterySteakToppingMushroomDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakToppingMushroomDish.cs
@@ -1,0 +1,74 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakToppingMushroomDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Steak - Mushroom Topping";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SteakToppingMushroom);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Mushroom\n" + 
+                "Chop a mushroom, then plate with any  <i>Steak</i> dish." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Steak Topping - Mushroom",
+                Description = "Adds Mushroom as a topping for any Steak dish",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BonedSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThickSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThinSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Steaks/MysterySteakToppingTomatoDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakToppingTomatoDish.cs
@@ -1,0 +1,74 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Steaks
+{
+    public class MysterySteakToppingTomatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Steak - Tomato Topping";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.SteakToppingTomato);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Tomato\n" + 
+                "Chop a tomato once, then plate with any  <i>Steak</i> dish." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Steak Topping - Tomato",
+                Description = "Adds Tomato as a topping for any Steak dish",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.SteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.BonedSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThickSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.ThinSteakPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TomatoChopped)
+            },
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFryBambooDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Stir Fry - Bamboo Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryBamboo);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Bamboo\n" + 
+                "Add raw bamboo to pot with water and boil. Portion and add to wok of stir fry ingredients." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry Bamboo",
+                Description = "Adds <b>Bamboo</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.BambooCookedContainerCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BambooRaw)
+        };
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBaseDish.cs
@@ -2,6 +2,7 @@
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMenu.Customs.Dishes;
+using KitchenMysteryMenu.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry",
                 Description = "Adds Stir Fry as a main when <b>Rice</b> and one of <b>Carrot</b> or <b>Broccoli</b> are present",
-                FlavourText = "Cook after adding each ingredient!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 

--- a/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry Broccoli",
                 Description = "Adds <b>Broccoli</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()

--- a/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry Carrot",
                 Description = "Adds <b>Carrot</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
-                FlavourText = "Nyehhhh *crunch* What's up, Doc?"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()

--- a/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFryMushroomDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Stir Fry - Mushroom";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryMushroom);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Mushroom\n" + 
+                "Chop mushroom and add to wok of stir fry ingredients." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry - Mushroom",
+                Description = "Adds <b>Mushroom</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChoppedContainerCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom)
+        };
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryRiceDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry Rice",
                 Description = "Adds Rice as a <b>REQUIRED</b> ingredient for Stir Fry.",
-                FlavourText = "This card is solely to make Stir Fry work with the Mystery Menu daily selections."
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()

--- a/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
@@ -36,7 +36,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry - Soy Sauce",
                 Description = "Adds Soy Sauce as a possible extra after serving Dumplings.",
-                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()

--- a/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
@@ -1,0 +1,60 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFrySoySauceDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Stir Fry - Soy Sauce";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFrySoySauce);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Soy Sauce\n" + 
+                "After serving  <i>Stir Fry</i>, customers may request Soy Sauce as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry - Soy Sauce",
+                Description = "Adds Soy Sauce as a possible extra after serving Dumplings.",
+                FlavourText = "(alsoAddsRecipes card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CondimentSoySauce)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CondimentSoySauce),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
+        };
+        public override bool RequiresVariant => true;
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
@@ -55,6 +55,5 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
-        public override bool RequiresVariant => true;
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.StirFry
+{
+    public class MysteryStirFrySteakDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Stir Fry Steak Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.StirFryMeat);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>Stir Fry in Wok</i>, Meat\n" + 
+                "Chop meat and add to wok of stir fry ingredients." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Stir Fry Steak",
+                Description = "Adds <b>Steak</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new List<Unlock>()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCarnivoreVariationsDish>()
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChoppedContainerCooked)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat)
+        };
+    }
+}

--- a/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             {
                 Name = "Mystery - Stir Fry Steak",
                 Description = "Adds <b>Steak</b> as an ingredient for Stir Fry when it's present with <b>Rice</b>",
-                FlavourText = ""
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Unlock> HardcodedRequirements => new List<Unlock>()

--- a/Customs/Dishes/Turkey/MysteryNutRoastDish.cs
+++ b/Customs/Dishes/Turkey/MysteryNutRoastDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Turkey
+{
+    public class MysteryNutRoastDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Nut Roast";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.NutRoastBase);
+        public override DishType Type => DishType.Main;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Onion, Nuts\n" +
+                "Chop onions. Chop nuts. Combine and cook.\n" +
+                "Portion nut roast onto a plate. Serves 3 portions." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Nut Roast",
+                Description = "Adds nut roast as a main when <b>Nuts</b> and <b>Onions</b> are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.NutRoastPlated),
+                Phase = MenuPhase.Main,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.NutsIngredient),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuVeggieVariationsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyBaseDish.cs
@@ -35,7 +35,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
             {
                 Name = "Mystery - Turkey",
                 Description = "Adds <b>Turkey</b> as a main when it is present",
-                FlavourText = "Gobble gobble gobble!"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override List<Dish.MenuItem> ResultingMenuItems => new()

--- a/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
             {
                 Name = "Mystery - Turkey - Cranberry Sauce",
                 Description = "Adds Cranberry Sauce as an option for Turkey",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()

--- a/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Turkey
+{
+    public class MysteryTurkeyCranberrySauceDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Mystery Turkey Cranberry Sauce Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TurkeyCranberrySauce);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Cranberries, Sugar\n" + 
+                "Chop cranberries, then combine with sugar to make sauce.\n" +
+                "Plate with  <i>Turkey</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Turkey - Cranberry Sauce",
+                Description = "Adds Cranberry Sauce as an option for Turkey",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TurkeyPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.CranberrySauce)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cranberries),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+        };
+    }
+}

--- a/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
@@ -37,7 +37,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
             {
                 Name = "Mystery - Turkey - Gravy",
                 Description = "Adds Gravy as an option for Turkey",
-                FlavourText = "(placeholder card, do not add with Cards Manager)"
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
         public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()

--- a/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
@@ -1,4 +1,5 @@
 ﻿using KitchenData;
+using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMenu.Utils;
@@ -8,13 +9,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
+namespace KitchenMysteryMenu.Customs.Dishes.Turkey
 {
-    public class MysterySpaghettiBaseDish : GenericMysteryDish
+    public class MysteryTurkeyGravyDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Spaghetti Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(References.SpaghettiBaseDish);
-        public override DishType Type => DishType.Base;
+        protected override string NameTag => "Mystery Turkey Gravy Dish";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TurkeyGravy);
+        public override DishType Type => DishType.Extra;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
@@ -26,37 +27,35 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Tomato, Spaghetti\n" +
-                "Put raw spaghetti into a pot with water and boil, then empty the water into the trash. " +
-                "Chop tomato twice to make sauce. Combine boiled pasta on a plate with the sauce." }
+                "<color=yellow>Requires ingredient:</color> Onion, Turkey\n" + 
+                "Cook onion in a pot of water to make broth. Add a turkey carcass to the broth and cook again.\n" +
+                "Plate with  <i>Turkey</i>." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Spaghetti",
-                Description = "Adds spaghetti as a main when <b>Tomatoes</b> and <b>Raw Spaghetti</b> are present",
-                FlavourText = ""
+                Name = "Mystery - Turkey - Gravy",
+                Description = "Adds Gravy as an option for Turkey",
+                FlavourText = "(placeholder card, do not add with Cards Manager)"
             })
         };
-
-        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
         {
-            new()
+            new Dish.IngredientUnlock()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(References.SpaghettiPomodoroPlated/*Spaghetti Pomodoro Plated*/),
-                Phase = MenuPhase.Main,
-                Weight = 1
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TurkeyPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TurkeyGravy)
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato),
-            (Item) GDOUtils.GetExistingGDO(References.SpaghettiRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.TurkeyIngredient),
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Turkey
+{
+    public class MysteryTurkeyStuffingDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Turkey - Stuffing";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TurkeyStuffing);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate);
+        public override bool RequiredNoDishItem => false;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredient:</color> Flour, Onion\n" + 
+                "Knead (or add water to) flour to make dough. Cook to make bread. Portion a slice of bread and " +
+                "toast it. Chop the toast to make crumbs. Chop an onion and combine with crumbs, then cook.\n" +
+                "Plate with  <i>Turkey</i>." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Turkey - Stuffing",
+                Description = "Adds Stuffing as an option for Turkey",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new Dish.IngredientUnlock()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TurkeyPlated),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Stuffing)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
+        };
+    }
+}

--- a/Customs/Ingredients/MysteryApple.cs
+++ b/Customs/Ingredients/MysteryApple.cs
@@ -1,0 +1,30 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryApple : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Apple);
+        protected override string NameTag => "Mystery Apple";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra5>();
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        {
+            new()
+            {
+                Duration = 2f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.AppleSlices)
+            }
+        };
+    }
+}

--- a/Customs/Ingredients/MysteryCheese.cs
+++ b/Customs/Ingredients/MysteryCheese.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryCheese : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Cheese);
+        protected override string NameTag => "Mystery Cheese";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra7>();
+    }
+}

--- a/Customs/Ingredients/MysteryMushroom.cs
+++ b/Customs/Ingredients/MysteryMushroom.cs
@@ -1,0 +1,30 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryMushroom : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Mushroom);
+        protected override string NameTag => "Mystery Mushroom";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra6>();
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        {
+            new()
+            {
+                Duration = 2f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.MushroomChopped)
+            }
+        };
+    }
+}

--- a/Customs/Ingredients/MysteryOnion.cs
+++ b/Customs/Ingredients/MysteryOnion.cs
@@ -1,0 +1,30 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryOnion : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Onion);
+        protected override string NameTag => "Mystery Onion";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra2>();
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        {
+            new()
+            {
+                Duration = 2f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.OnionChopped)
+            }
+        };
+    }
+}

--- a/Customs/Ingredients/MysterySoySauce.cs
+++ b/Customs/Ingredients/MysterySoySauce.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysterySoySauce : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.CondimentSoySauce);
+        protected override string NameTag => "Mystery Soy Sauce";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra4>();
+    }
+}

--- a/Customs/Ingredients/MysterySurfNTurf.cs
+++ b/Customs/Ingredients/MysterySurfNTurf.cs
@@ -1,0 +1,30 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysterySurfNTurf : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.FishBlueRaw);
+        protected override string NameTag => "Mystery SurfNTurf";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra>();
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        {
+            new()
+            {
+                Duration = 5f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Cook),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.FishBlueFried)
+            }
+        };
+    }
+}

--- a/Customs/Ingredients/MysteryWine.cs
+++ b/Customs/Ingredients/MysteryWine.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryWine : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.WineBottle);
+        protected override string NameTag => "Mystery Wine";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderExtra3>();
+    }
+}

--- a/Mod.cs
+++ b/Mod.cs
@@ -26,11 +26,11 @@ namespace KitchenMysteryMenu
 {
     public class Mod : BaseMod, IModSystem
     {
-        public const string MOD_GUID = "com.kailaria.mysterymenu";
+        public const string MOD_GUID = "kailaria.mysterymenu";
         public const string MOD_NAME = "MysteryMenu";
-        public const string MOD_VERSION = "0.1.0";
+        public const string MOD_VERSION = "0.0.1";
         public const string MOD_AUTHOR = "Kailaria";
-        public const string MOD_GAMEVERSION = ">=1.1.8";
+        public const string MOD_GAMEVERSION = ">=1.1.9";
 
         public static AssetBundle Bundle;
         public static KitchenLogger Logger;
@@ -63,6 +63,10 @@ namespace KitchenMysteryMenu
         {
             AddGameDataObject<MysteryIngredientProvider>();
             AddGameDataObject<MysteryIngredientProvider2>();
+            AddGameDataObject<MysteryIngredientProviderExtra>();
+            AddGameDataObject<MysteryIngredientProviderExtra2>();
+            AddGameDataObject<MysteryIngredientProviderExtra3>();
+            //AddGameDataObject<MysteryIngredientProvider2>();
         }
 
         private void AddIngredientGDOs()
@@ -70,6 +74,9 @@ namespace KitchenMysteryMenu
             // For the HQ Kitchen to work with minimal extra code
             AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryFlour>();
+            AddGameDataObject<MysterySurfNTurf>();
+            AddGameDataObject<MysteryOnion>();
+            AddGameDataObject<MysteryWine>();
         }
 
         private void AddItemGroupGDOs()
@@ -82,6 +89,11 @@ namespace KitchenMysteryMenu
 
         private void AddDishGDOs()
         {
+            // Mystery Dish cards
+            AddGameDataObject<MysteryMenuBaseMainsDish>();
+            AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
+            AddGameDataObject<MysteryMenuSaucesDish>();
+
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
 
@@ -113,14 +125,18 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysterySaladBaseDish>();
             AddGameDataObject<MysterySaladTomatoDish>();
 
-            // Mystery Pizza Dishes
+            // Mystery Spaghetti Dishes
             AddGameDataObject<MysterySpaghettiBaseDish>();
+            AddGameDataObject<MysterySpaghettiBologneseDish>();
+            AddGameDataObject<MysterySpaghettiCheesyDish>();
 
             // Mystery Steak Dishes
             AddGameDataObject<MysterySteakBaseDish>();
             AddGameDataObject<MysterySteakBonedDish>();
             AddGameDataObject<MysterySteakThickDish>();
             AddGameDataObject<MysterySteakThinDish>();
+            AddGameDataObject<MysterySteakSauceMushroomSauceDish>();
+            AddGameDataObject<MysterySteakSauceRedWineJusDish>();
 
             // Mystery Stir Fry Dishes
             AddGameDataObject<MysteryStirFryBaseDish>();
@@ -131,10 +147,8 @@ namespace KitchenMysteryMenu
 
             // Mystery Turkey Dishes
             AddGameDataObject<MysteryTurkeyBaseDish>();
-
-            // Mystery Dish cards
-            AddGameDataObject<MysteryMenuBaseMainsDish>();
-            AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
+            AddGameDataObject<MysteryTurkeyCranberrySauceDish>();
+            AddGameDataObject<MysteryTurkeyGravyDish>();
         }
     }
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -94,6 +94,10 @@ namespace KitchenMysteryMenu
             // Mystery Fish Dishes
             AddGameDataObject<MysteryFishBlueDish>();
             AddGameDataObject<MysteryFishPinkDish>();
+            AddGameDataObject<MysteryFishCrabCakeDish>();
+            AddGameDataObject<MysteryFishFilletDish>();
+            AddGameDataObject<MysteryFishOysterDish>();
+            AddGameDataObject<MysteryFishSpinyDish>();
 
             // Mystery Hot Dog Dishes
             AddGameDataObject<MysteryHotdogBaseDish>();
@@ -114,18 +118,23 @@ namespace KitchenMysteryMenu
 
             // Mystery Steak Dishes
             AddGameDataObject<MysterySteakBaseDish>();
+            AddGameDataObject<MysterySteakBonedDish>();
+            AddGameDataObject<MysterySteakThickDish>();
+            AddGameDataObject<MysterySteakThinDish>();
 
             // Mystery Stir Fry Dishes
             AddGameDataObject<MysteryStirFryBaseDish>();
             AddGameDataObject<MysteryStirFryRiceDish>();
             AddGameDataObject<MysteryStirFryBroccoliDish>();
             AddGameDataObject<MysteryStirFryCarrotDish>();
+            AddGameDataObject<MysteryStirFrySteakDish>();
 
             // Mystery Turkey Dishes
             AddGameDataObject<MysteryTurkeyBaseDish>();
 
             // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();
+            AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
         }
     }
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -69,12 +69,14 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra4>();
             AddGameDataObject<MysteryIngredientProviderExtra5>();
             AddGameDataObject<MysteryIngredientProviderExtra6>();
+            AddGameDataObject<MysteryIngredientProviderExtra7>();
         }
 
         private void AddIngredientGDOs()
         {
             // For the HQ Kitchen to work with minimal extra code
             AddGameDataObject<MysteryApple>();
+            AddGameDataObject<MysteryCheese>();
             AddGameDataObject<MysteryFlour>();
             AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryMushroom>();
@@ -99,17 +101,26 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesDish>();
+            AddGameDataObject<MysteryMenuToppingsDish>();
             AddGameDataObject<MysteryMenuVeggieVariationsDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
+            AddGameDataObject<MysteryBreakfastToppingBeansDish>();
+            AddGameDataObject<MysteryBreakfastToppingEggsDish>();
+            AddGameDataObject<MysteryBreakfastToppingMushroomDish>();
+            AddGameDataObject<MysteryBreakfastToppingTomatoDish>();
 
             // Mystery Burger Dishes
             AddGameDataObject<MysteryBurgerBaseDish>();
+            AddGameDataObject<MysteryBurgerToppingCheeseDish>();
+            AddGameDataObject<MysteryBurgerToppingOnionDish>();
+            AddGameDataObject<MysteryBurgerToppingTomatoDish>();
 
             // Mystery Dumplings Dishes
             AddGameDataObject<MysteryDumplingsBaseDish>();
             AddGameDataObject<MysteryDumplingsSoySauceDish>();
+            AddGameDataObject<MysteryDumplingsSeaweedDish>();
 
             // Mystery Fish Dishes
             AddGameDataObject<MysteryFishBlueDish>();
@@ -138,6 +149,8 @@ namespace KitchenMysteryMenu
             // Mystery Salad Dishes
             AddGameDataObject<MysterySaladBaseDish>();
             AddGameDataObject<MysterySaladTomatoDish>();
+            AddGameDataObject<MysterySaladToppingOliveDish>();
+            AddGameDataObject<MysterySaladToppingOnionDish>();
             AddGameDataObject<MysterySaladAppleDish>();
             AddGameDataObject<MysterySaladPotatoDish>();
 
@@ -153,6 +166,8 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysterySteakThinDish>();
             AddGameDataObject<MysterySteakSauceMushroomSauceDish>();
             AddGameDataObject<MysterySteakSauceRedWineJusDish>();
+            AddGameDataObject<MysterySteakToppingMushroomDish>();
+            AddGameDataObject<MysterySteakToppingTomatoDish>();
 
             // Mystery Stir Fry Dishes
             AddGameDataObject<MysteryStirFryBaseDish>();
@@ -169,6 +184,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryNutRoastDish>();
             AddGameDataObject<MysteryTurkeyCranberrySauceDish>();
             AddGameDataObject<MysteryTurkeyGravyDish>();
+            AddGameDataObject<MysteryTurkeyStuffingDish>();
         }
     }
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -66,16 +66,17 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra>();
             AddGameDataObject<MysteryIngredientProviderExtra2>();
             AddGameDataObject<MysteryIngredientProviderExtra3>();
-            //AddGameDataObject<MysteryIngredientProvider2>();
+            AddGameDataObject<MysteryIngredientProviderExtra4>();
         }
 
         private void AddIngredientGDOs()
         {
             // For the HQ Kitchen to work with minimal extra code
-            AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryFlour>();
-            AddGameDataObject<MysterySurfNTurf>();
+            AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryOnion>();
+            AddGameDataObject<MysterySoySauce>();
+            AddGameDataObject<MysterySurfNTurf>();
             AddGameDataObject<MysteryWine>();
         }
 
@@ -92,6 +93,7 @@ namespace KitchenMysteryMenu
             // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
+            AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesDish>();
 
             // Mystery Breakfast Dishes
@@ -102,6 +104,7 @@ namespace KitchenMysteryMenu
 
             // Mystery Dumplings Dishes
             AddGameDataObject<MysteryDumplingsBaseDish>();
+            AddGameDataObject<MysteryDumplingsSoySauceDish>();
 
             // Mystery Fish Dishes
             AddGameDataObject<MysteryFishBlueDish>();
@@ -113,6 +116,8 @@ namespace KitchenMysteryMenu
 
             // Mystery Hot Dog Dishes
             AddGameDataObject<MysteryHotdogBaseDish>();
+            AddGameDataObject<MysteryHotdogKetchupDish>();
+            AddGameDataObject<MysteryHotdogMustardDish>();
 
             // Mystery Pies Dishes
             AddGameDataObject<MysteryPiesBaseDish>();
@@ -144,6 +149,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryStirFryBroccoliDish>();
             AddGameDataObject<MysteryStirFryCarrotDish>();
             AddGameDataObject<MysteryStirFrySteakDish>();
+            AddGameDataObject<MysteryStirFrySoySauceDish>();
 
             // Mystery Turkey Dishes
             AddGameDataObject<MysteryTurkeyBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -67,13 +67,17 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra2>();
             AddGameDataObject<MysteryIngredientProviderExtra3>();
             AddGameDataObject<MysteryIngredientProviderExtra4>();
+            AddGameDataObject<MysteryIngredientProviderExtra5>();
+            AddGameDataObject<MysteryIngredientProviderExtra6>();
         }
 
         private void AddIngredientGDOs()
         {
             // For the HQ Kitchen to work with minimal extra code
+            AddGameDataObject<MysteryApple>();
             AddGameDataObject<MysteryFlour>();
             AddGameDataObject<MysteryMeat>();
+            AddGameDataObject<MysteryMushroom>();
             AddGameDataObject<MysteryOnion>();
             AddGameDataObject<MysterySoySauce>();
             AddGameDataObject<MysterySurfNTurf>();
@@ -95,6 +99,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesDish>();
+            AddGameDataObject<MysteryMenuVeggieVariationsDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
@@ -122,13 +127,19 @@ namespace KitchenMysteryMenu
             // Mystery Pies Dishes
             AddGameDataObject<MysteryPiesBaseDish>();
             AddGameDataObject<MysteryPiesMeatDish>();
+            AddGameDataObject<MysteryPiesMushroomDish>();
+            AddGameDataObject<MysteryPiesVegetableDish>();
 
             // Mystery Pizza Dishes
             AddGameDataObject<MysteryPizzaBaseDish>();
+            AddGameDataObject<MysteryPizzaMushroomDish>();
+            AddGameDataObject<MysteryPizzaOnionDish>();
 
             // Mystery Salad Dishes
             AddGameDataObject<MysterySaladBaseDish>();
             AddGameDataObject<MysterySaladTomatoDish>();
+            AddGameDataObject<MysterySaladAppleDish>();
+            AddGameDataObject<MysterySaladPotatoDish>();
 
             // Mystery Spaghetti Dishes
             AddGameDataObject<MysterySpaghettiBaseDish>();
@@ -148,11 +159,14 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryStirFryRiceDish>();
             AddGameDataObject<MysteryStirFryBroccoliDish>();
             AddGameDataObject<MysteryStirFryCarrotDish>();
+            AddGameDataObject<MysteryStirFryBambooDish>();
+            AddGameDataObject<MysteryStirFryMushroomDish>();
             AddGameDataObject<MysteryStirFrySteakDish>();
             AddGameDataObject<MysteryStirFrySoySauceDish>();
 
             // Mystery Turkey Dishes
             AddGameDataObject<MysteryTurkeyBaseDish>();
+            AddGameDataObject<MysteryNutRoastDish>();
             AddGameDataObject<MysteryTurkeyCranberrySauceDish>();
             AddGameDataObject<MysteryTurkeyGravyDish>();
         }

--- a/Systems/HandleNewMysteryMenuDish.cs
+++ b/Systems/HandleNewMysteryMenuDish.cs
@@ -131,6 +131,9 @@ namespace KitchenMysteryMenu.Systems
                     // TODO: Handle case when Mystery Dish would be a duplicate of an existing Static/Dynamic Dish's CMenuItem (by removing the one with MysteryMenuItem.Type = Mystery).
                     // Point the CMenuItem's SourceDish to the MysteryDish's ID instead of its parent MysteryDishCard's ID
                     menuItem.SourceDish = genericMysteryDish.GameDataObject.ID;
+
+                    // Counteract HandleNewDish to make the weights more balanced when ordering since all menu items are bundled in large cards with this mod.
+                    menuItem.Weight = 1;
                     EntityManager.AddComponentData(entity, menuItem);
                 }
 
@@ -197,7 +200,51 @@ namespace KitchenMysteryMenu.Systems
 
         private void HandleNewExtras(Dish dishData, GenericMysteryDish genericMysteryDish, GenericMysteryDishCard genericMysteryDishCard)
         {
+            string soughtExtrasLog = "";
+            foreach (var ingredient in dishData.ExtraOrderUnlocks)
+            {
+                soughtExtrasLog += $"  {{MenuItem = {ingredient.MenuItem.ID}, Ingredient = {ingredient.Ingredient.ID}}}\n";
+            }
+            Mod.Logger.LogInfo($"Handling new menu extra; Looking for possible extras objects: [\n{soughtExtrasLog}]");
+            using var possibleExtrasEntities = NonHandledPossibleExtras.ToEntityArray(Allocator.Temp);
+            using var possibleExtras = NonHandledPossibleExtras.ToComponentDataArray<CPossibleExtra>(Allocator.Temp);
+            for (int i = 0; i < possibleExtrasEntities.Length; i++)
+            {
+                var entity = possibleExtrasEntities[i];
+                var possibleExtra = possibleExtras[i];
 
+                // Continue until we find the matching CAvailableIngredient. The relevant IngredientUnlock set will be a standard dish if non-mystery
+                //  or the MysteryDish's if it is mystery.
+                Mod.Logger.LogInfo($"[HandleNewMenuOptions] cPossibleExtra {{MenuItem = {possibleExtra.MenuItem}, Ingredient = {possibleExtra.Ingredient}}}");
+                HashSet<Dish.IngredientUnlock> relevantUISet = genericMysteryDish == default
+                    ? dishData.ExtraOrderUnlocks
+                    : genericMysteryDish.ExtraOrderUnlocks;
+                if (!relevantUISet.Any(ui => ui.MenuItem.ID == possibleExtra.MenuItem && ui.Ingredient.ID == possibleExtra.Ingredient))
+                {
+                    continue;
+                }
+
+                if (genericMysteryDish == default)
+                {
+                    // This is not a mystery dish, so give the entity the appropriate component to prevent it from showing up here again
+                    // TODO: do I want to actually add the recipe here..? Maybe worry about it when testing Autumn/Lake/Variety
+                    Mod.Logger.LogInfo("Option is *not* mystery; Adding CNonMysteryExtra");
+                    EntityManager.AddComponent<CNonMysteryExtra>(entity);
+                    break;
+                }
+
+                // This *is* a mystery dish option, so add the identifier component and the CMysteryMenuItem component so that we
+                //  know what ingredients will trigger this to be available.
+
+                Mod.Logger.LogInfo($"Creating CMysteryMenuItem and CMysteryMenuItemOption for entity {{Index = {entity.Index}}}");
+                EntityManager.AddComponentData(entity, new CMysteryMenuItem()
+                {
+                    Type = MysteryMenuType.Mystery,
+                    SourceMysteryDish = genericMysteryDish.GameDataObject.ID,
+                    HasBeenProvided = false
+                });
+                EntityManager.AddComponent<CMysteryMenuItemOption>(entity);
+            }
         }
     }
 }

--- a/Systems/HandleNewMysteryMenuDish.cs
+++ b/Systems/HandleNewMysteryMenuDish.cs
@@ -86,10 +86,10 @@ namespace KitchenMysteryMenu.Systems
                 var menuItem = cMenuItems[i];
 
                 // Continue until we find the matching non-mystery Dish or the matching MysteryDishCard
-                Mod.Logger.LogInfo($"[HandleNewMenuItems] cMenuItem.SourceDish {{{menuItem.SourceDish}}}; dishData.ID {{{dishData.ID}}}; " +
-                    $"gMD.GDO.ID {{{genericMysteryDish?.GameDataObject.ID}}}; mDC.GDO.ID {{{mysteryDishCard?.GameDataObject.ID}}}");
                 int relevantSourceDishID = mysteryDishCard == default ? dishData.ID : mysteryDishCard.GameDataObject.ID;
-                if (menuItem.SourceDish != relevantSourceDishID)
+                Mod.Logger.LogInfo($"[HandleNewMenuItems] cMenuItem.SourceDish {{{menuItem.SourceDish}}}; cMenuItem.Item {{{menuItem.Item}}}; dishData.ID {{{dishData.ID}}}; " +
+                    $"gMD.GDO.ID {{{genericMysteryDish?.GameDataObject.ID}}}; mDC.GDO.ID {{{mysteryDishCard?.GameDataObject.ID}}}; gmd.UniqueNameID {{{genericMysteryDish?.UniqueNameID}}}");
+                if (menuItem.SourceDish != relevantSourceDishID || !genericMysteryDish.ResultingMenuItems.Any(rmi => rmi.Item.ID == menuItem.Item))
                 {
                     continue;
                 }

--- a/Utils/References.cs
+++ b/Utils/References.cs
@@ -14,5 +14,22 @@ namespace KitchenMysteryMenu.Utils
         public static readonly GameDataObject MysteryMenuBaseDish = GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>();
         public static readonly DynamicMenuType DynamicMenuTypeMystery = (DynamicMenuType)VariousUtils.GetID($"{Mod.MOD_GUID}:{((Dish)MysteryMenuBaseDish).Name}");
         public static readonly int MaxIngredientCountForMinimumRecipe = 5;
+
+        // Temporary until KitchenLib updates w/ Spaghetti
+        public static int SpaghettiBaseDish = 1764920765;
+        public static int SpaghettiBologneseDish = -1501485763;
+        public static int SpaghettiCheesyDish = 1651927267;
+        public static int LasagneDish = 803049136;
+
+        public static int SpaghettiPomodoroPlated = 1900532137;
+        public static int SpaghettiBolognesePlated = -1711635749;
+        public static int SpaghettiCheesyPlated = -383718493;
+        public static int LasagnePlated = 82891941;
+
+        public static int SpaghettiRaw = -823534126;
+        public static int MinceRaw = -2047874552;
+        public static int Butter = 1605072344;
+        public static int LasagnePastaSheet = 1521319349;
+        public static int LasagneTray = -2080052245;
     }
 }

--- a/Utils/References.cs
+++ b/Utils/References.cs
@@ -15,6 +15,8 @@ namespace KitchenMysteryMenu.Utils
         public static readonly DynamicMenuType DynamicMenuTypeMystery = (DynamicMenuType)VariousUtils.GetID($"{Mod.MOD_GUID}:{((Dish)MysteryMenuBaseDish).Name}");
         public static readonly int MaxIngredientCountForMinimumRecipe = 5;
 
+        public static string DishCardDoNotAddFlavorText = "(alsoAddsRecipes card, do not add with Cards Manager)";
+
         // Temporary until KitchenLib updates w/ Spaghetti
         public static int SpaghettiBaseDish = 1764920765;
         public static int SpaghettiBologneseDish = -1501485763;

--- a/Utils/References.cs
+++ b/Utils/References.cs
@@ -27,7 +27,7 @@ namespace KitchenMysteryMenu.Utils
         public static int LasagnePlated = 82891941;
 
         public static int SpaghettiRaw = -823534126;
-        public static int MinceRaw = -2047874552;
+        public static int Mince = -2047874552;
         public static int Butter = 1605072344;
         public static int LasagnePastaSheet = 1521319349;
         public static int LasagneTray = -2080052245;


### PR DESCRIPTION
* Adds all of the potential recipes that have a base main as a prerequisite (except Christmas Crackers, since they don't modify the main dish or provide an alternative).
* Groups them into a first draft of groupings based on similarity of topic and keeping to the same approximate amount of recipes as the base Mystery Menu card or, barring that, making up for it with less customer reduction or more providers