### PR TITLE
Add non main phases

### DIFF
--- a/Customs/Appliances/MysteryCakePanProvider.cs
+++ b/Customs/Appliances/MysteryCakePanProvider.cs
@@ -1,0 +1,50 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryCakePanProvider : CustomAppliance
+    {
+        public override string UniqueNameID => "Mystery Cake Pan Provider";
+        public override GameObject Prefab => ((Appliance) GDOUtils.GetExistingGDO(ApplianceReferences.SourceCookieTray)).Prefab;
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        {
+            new CMysteryMenuProvider() {
+                Type = Utils.MysteryMenuType.MysteryPan
+            },
+            new CItemHolder()
+        };
+        public override bool IsNonInteractive => false;
+        public override OccupancyLayer Layer => OccupancyLayer.Default;
+        public override bool IsPurchasable => false;
+        public override bool IsPurchasableAsUpgrade => false;
+        public override DecorationType ThemeRequired => DecorationType.Null;
+        public override ShoppingTags ShoppingTags => ShoppingTags.Basic;
+        public override RarityTier RarityTier => RarityTier.Special;
+        public override PriceTier PriceTier => PriceTier.Free;
+        public override bool StapleWhenMissing => false;
+        public override bool SellOnlyAsDuplicate => false;
+        public override bool PreventSale => true;
+        public override bool IsNonCrated => false;
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                { 
+                    Name = "Mystery Menu - Mystery Tray",
+                    Description = "Provides a random tray/tin/pan for the mystery menu each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderBoard.cs
+++ b/Customs/Appliances/MysteryIngredientProviderBoard.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderBoard : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Board";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderBoard2.cs
+++ b/Customs/Appliances/MysteryIngredientProviderBoard2.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderBoard2 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Board 2";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderCakes.cs
+++ b/Customs/Appliances/MysteryIngredientProviderCakes.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderCakes : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Cakes";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderCakes2.cs
+++ b/Customs/Appliances/MysteryIngredientProviderCakes2.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderCakes2 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Cakes 2";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderCakes3.cs
+++ b/Customs/Appliances/MysteryIngredientProviderCakes3.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderCakes3 : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Cakes 3";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryIngredientProviderSides.cs
+++ b/Customs/Appliances/MysteryIngredientProviderSides.cs
@@ -1,0 +1,30 @@
+﻿using Kitchen;
+using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Appliances
+{
+    public class MysteryIngredientProviderSides : MysteryIngredientProvider
+    {
+        public override string UniqueNameID => "Mystery Ingredient Provider Sides";
+
+        public override List<(Locale, ApplianceInfo)> InfoList => new List<(Locale, ApplianceInfo)>()
+        {
+            (Locale.English, new ApplianceInfo()
+                {
+                    Name = "Mystery Menu - Provider",
+                    Description = "Provides ingredients for the mystery menu, randomized each day."
+                })
+        };
+    }
+}

--- a/Customs/Appliances/MysteryTrayProviderCakes.cs
+++ b/Customs/Appliances/MysteryTrayProviderCakes.cs
@@ -16,15 +16,23 @@ namespace KitchenMysteryMenu.Customs.Appliances
 {
     public class MysteryTrayProviderCakes : CustomAppliance
     {
-        public override string UniqueNameID => "Mystery Pastry Tray Provider";
+        public override string UniqueNameID => "Mystery Tray Provider";
         public override GameObject Prefab => ((Appliance) GDOUtils.GetExistingGDO(ApplianceReferences.SourceCookieTray)).Prefab;
         public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
         {
             new CMysteryMenuProvider() {
-                Type = Utils.MysteryMenuType.MysteryPan
+                Type = Utils.MysteryMenuType.MysteryTray
+            },
+            new CItemProvider() {
+                ProvidedItem = 0,
+                Available = 0,
+                Maximum = 1,
+                PreventReturns = true
             },
             new CItemHolder()
         };
+        public override List<Appliance.ApplianceProcesses> Processes => 
+            ((Appliance) GDOUtils.GetExistingGDO(ApplianceReferences.SourceCookieTray)).Processes.ToList();
         public override bool IsNonInteractive => false;
         public override OccupancyLayer Layer => OccupancyLayer.Default;
         public override bool IsPurchasable => false;

--- a/Customs/Appliances/MysteryTrayProviderCakes.cs
+++ b/Customs/Appliances/MysteryTrayProviderCakes.cs
@@ -14,9 +14,9 @@ using UnityEngine;
 
 namespace KitchenMysteryMenu.Customs.Appliances
 {
-    public class MysteryCakePanProvider : CustomAppliance
+    public class MysteryTrayProviderCakes : CustomAppliance
     {
-        public override string UniqueNameID => "Mystery Cake Pan Provider";
+        public override string UniqueNameID => "Mystery Pastry Tray Provider";
         public override GameObject Prefab => ((Appliance) GDOUtils.GetExistingGDO(ApplianceReferences.SourceCookieTray)).Prefab;
         public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
         {

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingBeansDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingBeansDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>();
     }
 }

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingEggsDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingEggsDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>();
     }
 }

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingMushroomDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingMushroomDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>();
     }
 }

--- a/Customs/Dishes/Breakfast/MysteryBreakfastToppingTomatoDish.cs
+++ b/Customs/Dishes/Breakfast/MysteryBreakfastToppingTomatoDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Breakfast
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreakfastBaseDish>();
     }
 }

--- a/Customs/Dishes/Burger/MysteryBurgerToppingCheeseDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingCheeseDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Burger
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerBaseDish>();
     }
 }

--- a/Customs/Dishes/Burger/MysteryBurgerToppingOnionDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingOnionDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Burger
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerBaseDish>();
     }
 }

--- a/Customs/Dishes/Burger/MysteryBurgerToppingTomatoDish.cs
+++ b/Customs/Dishes/Burger/MysteryBurgerToppingTomatoDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Burger
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBurgerBaseDish>();
     }
 }

--- a/Customs/Dishes/Cakes/MysteryCakeBatterRecipe.cs
+++ b/Customs/Dishes/Cakes/MysteryCakeBatterRecipe.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakeBatterRecipe : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
+        protected override string NameTag => "Cake Batter Recipe";
         public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
@@ -26,38 +26,26 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Flour, Egg, Sugar\n" +
+                "RECIPE ONLY\n" +
+                $"Crack (chop) an egg. Combine cracked egg with a mixing bowl, flour, and sugar and knead to make " +
+                $"{References.ColorTextCakeBatter}."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cake Batter (recipe only)",
+                Description = "",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
 
         public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
-            new()
-            {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
-                Phase = MenuPhase.Dessert,
-                Weight = 1
-            }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Cakes/MysteryCakesChocolateCookieDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesChocolateCookieDish.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesChocolateCookieDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
+        protected override string NameTag => "Cake - Chocolate Cookies";
         public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
@@ -26,18 +26,17 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
+                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Chocolate\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Melt (cook) chocolate. Combine the chocolate in the " +
                 "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                $"Portion up to 4 times and serve to customers ordering chocolate flavour {References.PinkTintCakesText} for dessert."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Chocolate Cookies",
+                Description = "Adds chocolate cookies as a dessert when flour, egg, sugar, chocolate, and a cookie tray are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,7 +45,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ChocolateFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
@@ -57,13 +56,14 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Chocolate)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;
+        public override int BaseResultingItem => ItemReferences.Cookie;
     }
 }

--- a/Customs/Dishes/Cakes/MysteryCakesChocolateCupcakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesChocolateCupcakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesChocolateCupcakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Chocolate Cupcakes";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cupcake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Cupcake Tray, Flour, Egg, Sugar, Milk, Chocolate\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cupcake tray and cook the cupcakes.\n" +
+                "Melt (cook) a chocolate. Portion a cupcake (up to 4 per tray) and combine with the melted chocolate. " +
+                $"Serve to customers ordering chocolate flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Chocolate Cupcakes",
+                Description = "Adds chocolate cupcakes as a dessert when flour, egg, sugar, milk, chocolate, and a cupcake tray are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,22 +46,23 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ChocolateFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CupcakeTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Chocolate)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;

--- a/Customs/Dishes/Cakes/MysteryCakesChocolateSpongeCakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesChocolateSpongeCakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesChocolateSpongeCakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Chocolate Sponge Cake";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BigCake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Sponge Cake Tin (tray), Flour, Egg, Sugar, Milk, Chocolate\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cake tin and cook the sponge cake.\n" +
+                "Melt (cook) some chocolate. Combine the baked cake with the melted chocolate. " +
+                $"Portion (up to 6 times) and serve to customers ordering chocolate flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Chocolate Sponge Cake",
+                Description = "Adds chocolate sponge cake as a dessert when flour, egg, sugar, milk, chocolate, and a cake tin are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,22 +46,23 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ChocolateFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BigCakeTin),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Chocolate)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;

--- a/Customs/Dishes/Cakes/MysteryCakesCoffeeCookieDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesCoffeeCookieDish.cs
@@ -1,0 +1,66 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+{
+    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Cakes - Coffee Cookies";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
+                "Mix  <color=pink><i>Cake Batter</i></color> in a mixing bowl. Brew a cup of coffee. Combine the coffee in the" +
+                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
+                "Portion up to 4 times and serve to customers ordering coffee flavour cakes for dessert."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Cakes - Coffee Cookies",
+                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Phase = MenuPhase.Dessert,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+    }
+}

--- a/Customs/Dishes/Cakes/MysteryCakesCoffeeCupcakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesCoffeeCupcakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesCoffeeCupcakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Coffee Cupcakes";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cupcake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Cupcake Tray, Flour, Egg, Sugar, Milk, Coffee Cup\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cupcake tray and cook the cupcakes.\n" +
+                "Brew a cup of coffee. Portion a cupcake (up to 4 per tray) and combine with the cup of coffee. " +
+                $"Serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Coffee Cupcakes",
+                Description = "Adds coffee cupcakes as a dessert when flour, egg, sugar, milk, coffee, and a cupcake tray are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -53,10 +53,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CupcakeTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
         };
         public override List<Unlock> HardcodedRequirements => new()

--- a/Customs/Dishes/Cakes/MysteryCakesCoffeeSpongeCakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesCoffeeSpongeCakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesCoffeeSpongeCakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Coffee Sponge Cake";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BigCake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Sponge Cake Tin (tray), Flour, Egg, Sugar, Milk, Coffee Cup\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cake tin and cook the sponge cake.\n" +
+                "Brew a cup of coffee. Combine the baked cake with the cup of coffee. " +
+                $"Portion (up to 6 times) and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Coffee Sponge Cake",
+                Description = "Adds coffee sponge cake as a dessert when flour, egg, sugar, milk, coffee, and a cake tin are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -53,10 +53,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BigCakeTin),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
         };
         public override List<Unlock> HardcodedRequirements => new()

--- a/Customs/Dishes/Cakes/MysteryCakesLemonCookieDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesLemonCookieDish.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesLemonCookieDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
+        protected override string NameTag => "Cake - Lemon Cookies";
         public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
+                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Lemon\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Chop a lemon. Combine the lemon in the " +
                 "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                $"Portion up to 4 times and serve to customers ordering lemon flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Lemon Cookies",
+                Description = "Adds lemon cookies as a dessert when flour, egg, sugar, lemon, and a cookie tray are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,7 +46,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.LemonFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
@@ -57,11 +57,11 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Lemon)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;

--- a/Customs/Dishes/Cakes/MysteryCakesLemonCupcakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesLemonCupcakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesLemonCupcakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Lemon Cupcakes";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cupcake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Cupcake Tray, Flour, Egg, Sugar, Milk, Lemon\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cupcake tray and cook the cupcakes.\n" +
+                "Chop a lemon. Portion a cupcake (up to 4 per tray) and combine with the chopped lemon. " +
+                $"Serve to customers ordering lemon flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Lemon Cupcakes",
+                Description = "Adds lemon cupcakes as a dessert when flour, egg, sugar, milk, lemon, and a cupcake tray are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,22 +46,23 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.LemonFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CupcakeTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Lemon)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;

--- a/Customs/Dishes/Cakes/MysteryCakesLemonSpongeCakeDish.cs
+++ b/Customs/Dishes/Cakes/MysteryCakesLemonSpongeCakeDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Cakes
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCakesLemonSpongeCakeDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cake - Lemon Sponge Cake";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BigCake);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Sponge Cake Tin (tray), Flour, Egg, Sugar, Milk, Lemon\n" +
+                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Add milk to the Cake Batter, then pour into cake tin and cook the sponge cake.\n" +
+                "Chop a lemon. Combine the baked cake with the chopped lemon. " +
+                $"Portion (up to 6 times) and serve to customers ordering lemon flavour {References.PinkTintCakesText} for dessert."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Cakes - Lemon Sponge Cake",
+                Description = "Adds lemon sponge cake as a dessert when flour, egg, sugar, milk, lemon, and a cake tin are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,22 +46,23 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.LemonFlavour),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BigCakeTin),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Lemon)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override bool HasTrayIngredient => true;

--- a/Customs/Dishes/Coffee/MysteryCoffeeBaseDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeBaseDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCoffeeBaseDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Coffee - Base";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CoffeeBaseDessert);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Coffee Cup\n" +
+                "Place a cup of coffee on a coffee machine to brew, then serve as a dessert.\n" +
+                $"Counts as a {References.ColorTextHotDrink}."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Black Coffee",
+                Description = "Adds coffee as a dessert when coffee cups are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,17 +44,13 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCupCoffee),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
         };
         public override List<Unlock> HardcodedRequirements => new()
@@ -64,6 +58,5 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
     }
 }

--- a/Customs/Dishes/Coffee/MysteryCoffeeCakeStandDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeCakeStandDish.cs
@@ -1,0 +1,77 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
+{
+    public class MysteryCoffeeCakeStandDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Coffee - Cake Stand";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CoffeeCakeStand);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => default;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires tray:</color> Cake Stand\n" + 
+                $"After serving a {References.ColorTextHotDrink}, customers may request the Cake Stand as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Coffee - Cake Stand",
+                Description = "Adds Cake Stand as a possible extra after serving a cup of Coffee.",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCupCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.ExtraCakeStand)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.Latte),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.ExtraCakeStand)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IcedCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.ExtraCakeStand)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TeaPotSteeped),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.ExtraCakeStand)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.ExtraCakeStand),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+        };
+        public override bool HasTrayIngredient => true;
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>();
+    }
+}

--- a/Customs/Dishes/Coffee/MysteryCoffeeExtraMilkDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeExtraMilkDish.cs
@@ -1,0 +1,76 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
+{
+    public class MysteryCoffeeExtraMilkDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Coffee - Extra Milk";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.ExtraMilk);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => default;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires tray:</color> Milk\n" +
+                $"After serving a {References.ColorTextHotDrink}, customers may request milk as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Coffee - Extra Milk",
+                Description = "Adds milk as a possible extra after serving a coffee drink.",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCupCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Milk)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.Latte),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Milk)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IcedCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Milk)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TeaPotSteeped),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Milk)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>();
+    }
+}

--- a/Customs/Dishes/Coffee/MysteryCoffeeExtraSugarDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeExtraSugarDish.cs
@@ -1,0 +1,76 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
+{
+    public class MysteryCoffeeExtraSugarDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Coffee - Extra Sugar";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.ExtraSugar);
+        public override DishType Type => DishType.Extra;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override Item RequiredDishItem => default;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires tray:</color> Sugar\n" +
+                $"After serving a {References.ColorTextHotDrink}, customers may request sugar as an extra if available." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Coffee - Extra Sugar",
+                Description = "Adds sugar as a possible extra after serving a coffee drink.",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCupCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Sugar)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.Latte),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Sugar)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IcedCoffee),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Sugar)
+            },
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TeaPotSteeped),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.Sugar)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>();
+    }
+}

--- a/Customs/Dishes/Coffee/MysteryCoffeeIcedDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeIcedDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCoffeeIcedDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Coffee - Iced";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CoffeeIced);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,17 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Coffee Cup, Ice\n" +
+                "Place a cup of coffee on a coffee machine to brew. Wait for Ice to build up in the Ice Dispenser. " +
+                "Place the cup of coffee on the dispenser and combine to make an Iced Coffee, then serve as a dessert.\n" +
+                $"Counts as a {References.ColorTextHotDrink}."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Iced Coffee",
+                Description = "Adds iced coffee as a dessert when coffee cups and ice are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +45,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.IcedCoffee),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>();
     }
 }

--- a/Customs/Dishes/Coffee/MysteryCoffeeLatteDish.cs
+++ b/Customs/Dishes/Coffee/MysteryCoffeeLatteDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCoffeeLatteDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Coffee - Latte";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CoffeeLatte);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Coffee Cup, Milk\n" +
+                "Place a cup of coffee on a coffee machine to brew. Place milk into the frother. " +
+                "Place the cup of coffee on the milk frother and interact to make a Latte, then serve as a dessert.\n" +
+                $"Counts as a {References.ColorTextHotDrink}."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Latte",
+                Description = "Adds latte as a dessert when coffee cups and milk are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +46,21 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.Latte),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Milk)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>();
     }
 }

--- a/Customs/Dishes/Coffee/MysteryTeaDish.cs
+++ b/Customs/Dishes/Coffee/MysteryTeaDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Coffee
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryTeaDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Tea";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Tea);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,18 +26,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
+                "<color=yellow>Requires ingredients:</color> Tea pots, Tea bags, Tea Cups\n" +
+                "Combine a tea pot with a tea bag and water, then let steep. Serve the pot and a tea cup " +
+                "as a dessert. One tea pot serves up to 3 customers, but each needs their own cup.\n" +
+                $"Counts as a {References.ColorTextHotDrink}."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Tea",
+                Description = "Adds tea as a dessert when tea cups, tea pots, and tea bags are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +46,21 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.TeaPotSteeped), // TODO: check vanilla for the actual resulting menu item
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.TeaPot),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.TeaBag),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.TeaCup)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakeVarietyDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryApplePieDish.cs
+++ b/Customs/Dishes/Desserts/MysteryApplePieDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryApplePieDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Apple Pie";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PieApple);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,22 +22,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override bool IsUnlockable => false;
         public override bool RequiredNoDishItem => true;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 3;
+        public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Flour, Apples\n" +
+                "Knead flour (or add water) to make dough, then knead into pie crust and cook. " +
+                "Chop an apple, combine with the cooked crust, and cook again. Serve as a dessert."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Dessert - Apple Pie",
+                Description = "Adds apple pie as a dessert when flour and apples are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +44,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PieAppleCooked),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Apple)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryCheeseBoardDish.cs
+++ b/Customs/Dishes/Desserts/MysteryCheeseBoardDish.cs
@@ -9,13 +9,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Starters
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
 {
-    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    public class MysteryCheeseBoardDish : GenericMysteryDish
     {
-        protected override string NameTag => "Pumpkin Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
-        public override DishType Type => DishType.Starter;
+        protected override string NameTag => "Cheese Boards";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CheeseBoard);
+        public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
@@ -26,16 +26,17 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
-                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
-                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Serving Board, Cheese, Apple, Nuts\n" +
+                "Chop an apple. Place on a serving board with a wedge of cheese and some nuts, then " +
+                "serve as a dessert.\n" +
+                "Can be shared by up to two customers."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Pumpkin Soup",
-                Description = "Adds pumpkin soup as a starter when onion and pumpkins are present",
+                Name = "Mystery - Dessert - Cheese Board",
+                Description = "Adds cheese boards as a dessert when cheese, apples, and nuts are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,20 +45,21 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
-                Phase = MenuPhase.Starter,
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.CheeseBoardServing),
+                Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Apple),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.NutsIngredient)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
         };
-        public override MenuPhase MenuPhase => MenuPhase.Starter;
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryCherryPieDish.cs
+++ b/Customs/Dishes/Desserts/MysteryCherryPieDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryCherryPieDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Cherry Pie";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CherryPie);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,22 +22,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override bool IsUnlockable => false;
         public override bool RequiredNoDishItem => true;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 3;
+        public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Flour, Cherries\n" +
+                "Knead flour (or add water) to make dough, then knead into pie crust and cook. " +
+                "Add a cherry and cook again. Serve as a dessert."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Dessert - Cherry Pie",
+                Description = "Adds cherry pie as a dessert when flour and cherries are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +44,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PieCherryCooked),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cherry)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryIceCreamChocolateDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamChocolateDish.cs
@@ -58,5 +58,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Desserts
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+        public override bool PreventIngredientReturns => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryIceCreamChocolateDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamChocolateDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
+{
+    public class MysteryIceCreamChocolateDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Ice Cream Chocolate";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.IceCream);
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Chocolate Ice Cream\n" +
+                "Combine 2 to 3 ice cream scoops from the flavors available, then serve as a dessert."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dessert - Chocolate Ice Cream",
+                Description = "Adds chocolate ice cream as a potential ice cream flavor",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IceCreamServing),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.IceCreamChocolate)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.IceCreamChocolate)
+        };
+        public override bool RequiresVariant => false;
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            BaseMysteryDish.GameDataObject
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+    }
+}

--- a/Customs/Dishes/Desserts/MysteryIceCreamServingDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamServingDish.cs
@@ -1,0 +1,59 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
+{
+    public class MysteryIceCreamServingDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Ice Cream Serving";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.IceCream);
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color>  <i>At least one Ice Cream flavor</i>\n" +
+                "Combine 2 to 3 ice cream scoops from the flavors available, then serve as a dessert."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dessert - Ice Cream",
+                Description = "Adds ice cream as a dessert when any flavors are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.IceCreamServing),
+                Phase = MenuPhase.Dessert,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>();
+        public override bool RequiresVariant => true;
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+    }
+}

--- a/Customs/Dishes/Desserts/MysteryIceCreamStrawberryDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamStrawberryDish.cs
@@ -58,5 +58,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Desserts
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+        public override bool PreventIngredientReturns => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryIceCreamStrawberryDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamStrawberryDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
+{
+    public class MysteryIceCreamStrawberryDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Ice Cream Strawberry";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.IceCream);
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Strawberry Ice Cream\n" +
+                "Combine 2 to 3 ice cream scoops from the flavors available, then serve as a dessert."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dessert - Strawberry Ice Cream",
+                Description = "Adds strawberry ice cream as a potential ice cream flavor",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IceCreamServing),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.IceCreamStrawberry)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.IceCreamStrawberry)
+        };
+        public override bool RequiresVariant => false;
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            BaseMysteryDish.GameDataObject
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+    }
+}

--- a/Customs/Dishes/Desserts/MysteryIceCreamVanillaDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamVanillaDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
+{
+    public class MysteryIceCreamVanillaDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Ice Cream Vanilla";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.IceCream);
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Vanilla Ice Cream\n" +
+                "Combine 2 to 3 ice cream scoops from the flavors available, then serve as a dessert."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Dessert - Vanilla Ice Cream",
+                Description = "Adds vanilla ice cream as a potential ice cream flavor",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+        {
+            new()
+            {
+                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.IceCreamServing),
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.IceCreamVanilla)
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.IceCreamVanilla)
+        };
+        public override bool RequiresVariant => false;
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            BaseMysteryDish.GameDataObject
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Dessert;
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+    }
+}

--- a/Customs/Dishes/Desserts/MysteryIceCreamVanillaDish.cs
+++ b/Customs/Dishes/Desserts/MysteryIceCreamVanillaDish.cs
@@ -58,5 +58,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Desserts
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>();
+        public override bool PreventIngredientReturns => true;
     }
 }

--- a/Customs/Dishes/Desserts/MysteryPumpkinPieDish.cs
+++ b/Customs/Dishes/Desserts/MysteryPumpkinPieDish.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Cakes
+namespace KitchenMysteryMenu.Customs.Dishes.Desserts
 {
-    public class MysteryCakesCoffeeCookieDish : GenericMysteryDish
+    public class MysteryPumpkinPieDish : GenericMysteryDish
     {
-        protected override string NameTag => "Cake - Coffee Cookies";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cakes);
+        protected override string NameTag => "Pumpkin Pie";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PiePumpkin);
         public override DishType Type => DishType.Dessert;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -22,22 +22,22 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         public override bool IsUnlockable => false;
         public override bool RequiredNoDishItem => true;
         public override bool IsAvailableAsLobbyOption => false;
-        public override int Difficulty => 3;
+        public override int Difficulty => 2;
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Cookie Tray, Flour, Egg, Sugar, Coffee\n" +
-                $"Mix {References.ColorTextCakeBatter} in a mixing bowl. Brew a cup of coffee. Combine the coffee in the " +
-                "cake batter mixing bowl, and then pour into cookie tray. Cook the tray of cookies.\n" +
-                $"Portion up to 4 times and serve to customers ordering coffee flavour {References.PinkTintCakesText} for dessert."
-            }
+                "<color=yellow>Requires ingredients:</color> Flour, Pumpkin\n" +
+                "Knead flour (or add water) to make dough, then knead into pie crust and cook. " +
+                "Remove (portion) seeds from a pumpkin and discard them. Chop the hollowed pumpkin, " +
+                "then combine with the cooked crust, and cook again.\n" +
+                "Serve as a dessert."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Cakes - Coffee Cookies",
-                Description = "Adds coffee cookies as a dessert when flour, egg, sugar, coffee, and a cookie tray are present",
+                Name = "Mystery - Dessert - Pumpkin Pie",
+                Description = "Adds pumpkin pie as a dessert when flour and pumpkins are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -46,24 +46,20 @@ namespace KitchenMysteryMenu.Customs.Dishes.Cakes
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeFlavour),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PiePumpkinCooked),
                 Phase = MenuPhase.Dessert,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CookieTray),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Sugar),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Egg),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Dessert;
-        public override bool HasTrayIngredient => true;
     }
 }

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSeaweedDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSeaweedDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryDumplingsBaseDish>();
     }
 }

--- a/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
+++ b/Customs/Dishes/Dumplings/MysteryDumplingsSoySauceDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Dumplings
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryDumplingsBaseDish>();
     }
 }

--- a/Customs/Dishes/GenericMysteryDish.cs
+++ b/Customs/Dishes/GenericMysteryDish.cs
@@ -30,6 +30,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public virtual bool RequiresVariant => false;
         public virtual GenericMysteryDish BaseMysteryDish => default;
         public virtual MenuPhase MenuPhase => MenuPhase.Main;
+        public virtual bool PreventIngredientReturns => false;
 
         public override void OnRegister(Dish gameDataObject)
         {

--- a/Customs/Dishes/GenericMysteryDish.cs
+++ b/Customs/Dishes/GenericMysteryDish.cs
@@ -28,7 +28,9 @@ namespace KitchenMysteryMenu.Customs.Dishes
          *   like Pies and Stir Fry to ensure that their normal bases aren't needed to be available in order to be served.
          */
         public virtual bool RequiresVariant => false;
+        public virtual bool HasTrayIngredient => false;
         public virtual GenericMysteryDish BaseMysteryDish => default;
+        public virtual int BaseResultingItem => 0;
         public virtual MenuPhase MenuPhase => MenuPhase.Main;
         public virtual bool PreventIngredientReturns => false;
 

--- a/Customs/Dishes/GenericMysteryDish.cs
+++ b/Customs/Dishes/GenericMysteryDish.cs
@@ -29,6 +29,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
          */
         public virtual bool RequiresVariant => false;
         public virtual GenericMysteryDish BaseMysteryDish => default;
+        public virtual MenuPhase MenuPhase => MenuPhase.Main;
 
         public override void OnRegister(Dish gameDataObject)
         {

--- a/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogKetchupDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogBaseDish>();
     }
 }

--- a/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
+++ b/Customs/Dishes/HotDog/MysteryHotdogMustardDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.HotDog
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryHotdogBaseDish>();
     }
 }

--- a/Customs/Dishes/MysteryMenuBoardsTreatsDish.cs
+++ b/Customs/Dishes/MysteryMenuBoardsTreatsDish.cs
@@ -1,0 +1,85 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
+using KitchenMysteryMenu.Customs.Dishes.Desserts;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuBoardsTreatsDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Boards and Treats";
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryIceCreamStrawberry>(),
+            GDOUtils.GetCastedGDO<Item, MysteryIceCreamVanilla>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.ServingBoard)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of the remaining starters, plus Cheese Board & Ice Cream
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBreadBoardDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryChristmasCrackersDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryMandarinStarterDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPumpkinSeedDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCheeseBoardDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamServingDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamChocolateDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamStrawberryDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryIceCreamVanillaDish>()
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Starters</i> - Pumpkin Seeds" +
+                ", Bread (Boards), Christmas Crackers, Mandarin Starter.\n" +
+                "<i>Desserts</i> - Ice Cream (each flavor individually), Cheese Boards" +
+                "Adds two extra Mystery Ingredient Providers."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Boards & Treats",
+                Description = "Adds Bread Boards, Christmas Crackers, Mandarin Starter, and Pumpkin Seeds as possible starters.\n" +
+                "Adds Cheese Boards and Ice Cream as possible desserts (where each Ice Cream flavor takes up an entire provider)\n" +
+                "Provides two additional Mystery Ingredient Providers.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
@@ -21,7 +21,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
     {
         protected override string NameTag => "Carnivorous Variety";
         public override DishType Type => DishType.Main;
-        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
         public override bool IsUnlockable => true;

--- a/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuCarnivoreVariationsDish.cs
@@ -59,7 +59,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color> Thin-Cut Steak, Thick-Cut Steak, Bone-In Steak, " +
                 "Spiny Fish, Oysters, Fish Fillet, Crab Cakes, Steak Stir Fry\n" +
-                "Adds one extra Mystery Provider."
+                "Adds one extra Mystery Ingredient Provider."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/MysteryMenuCoffeeCakeVarietyDish.cs
+++ b/Customs/Dishes/MysteryMenuCoffeeCakeVarietyDish.cs
@@ -1,0 +1,94 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
+using KitchenMysteryMenu.Customs.Dishes.Desserts;
+using KitchenMysteryMenu.Customs.Appliances;
+using KitchenMysteryMenu.Customs.Dishes.Cakes;
+using KitchenMysteryMenu.Customs.Dishes.Coffee;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuCoffeeCakeVarietyDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Coffee Cake Variety";
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients (normally requires at minimum: flour, egg, sugar, [flavor])
+            GDOUtils.GetCastedGDO<Item, MysteryChocolate>(),
+            GDOUtils.GetCastedGDO<Item, MysteryTeapot>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.MixingBowlEmpty),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Ice)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.FillCoffee),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.FrothMilk),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.SteepTea)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of Coffee, Coffee-flavored cookies, cupcakes, and sponge cakes, and Pies
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesChocolateCookieDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesChocolateCupcakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesChocolateSpongeCakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesLemonCookieDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesLemonCupcakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesLemonSpongeCakeDish>(),
+
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeExtraMilkDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeExtraSugarDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeIcedDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeLatteDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTeaDish>()
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                $"<color=#00ffff>New possible menu items:</color> {References.ColorTextCakeFlavours} - Chocolate, Lemon\n" +
+                $"{References.ColorTextHotDrinks} - Lattes, Iced Coffee, Tea, Extra Milk, Extra Sugar\n" +
+                "Adds two extra Mystery Ingredient Providers."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Coffee & Cake - Varieties",
+                Description = $"Adds Chocolate and Lemon as possible {References.SpriteCake} Cake flavours.\n" +
+                $"Also adds Lattes, Iced Coffee, and Tea as alternative {References.SpriteFillCoffee} Hot Drinks, and Extra Sugar and Extra Milk for them when available.\n" +
+                "Provides two additional Mystery Ingredient Providers.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuCoffeeCakesPiesDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuCoffeeCakesPiesDish.cs
+++ b/Customs/Dishes/MysteryMenuCoffeeCakesPiesDish.cs
@@ -18,6 +18,7 @@ using KitchenMysteryMenu.Customs.Dishes.Starters;
 using KitchenMysteryMenu.Customs.Dishes.Desserts;
 using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes.Cakes;
+using KitchenMysteryMenu.Customs.Dishes.Coffee;
 
 namespace KitchenMysteryMenu.Customs.Dishes
 {
@@ -34,9 +35,9 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public override int Difficulty => 3;
         public override HashSet<Item> MinimumIngredients => new()
         {
-            // Add X Mystery Ingredients (normally requires flour, egg, sugar, [flavor]; 
-            GDOUtils.GetCastedGDO<Item, MysteryIngredientProviderCakes>(),
-            GDOUtils.GetCastedGDO<Item, MysteryTrayProviderCakes>(),
+            // Add X Mystery Ingredients (normally requires at minimum: flour, egg, sugar, [flavor])
+            GDOUtils.GetCastedGDO<Item, MysterySugar>(),
+            GDOUtils.GetCastedGDO<Item, MysteryCookieTray>(),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.MixingBowlEmpty)
         };
@@ -49,14 +50,23 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
         {
             // Add the Mystery versions of Coffee, Coffee-flavored cookies, cupcakes, and sponge cakes, and Pies
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakeBatterRecipe>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesCoffeeCookieDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesCoffeeCupcakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesCoffeeSpongeCakeDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeBaseDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCoffeeCakeStandDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryApplePieDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCherryPieDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPumpkinPieDish>(),
         };
 
         public override Dictionary<Locale, string> Recipe => new()
         {
-            { Locale.English, "<color=#00ffff>New possible menu items:</color> <i>Desserts</i> - Cherry Pie, Apple Pie, Pumpkin Pie, Coffee\n" +
-                "<i>Cake flavour</i> - Coffee\n" +
-                "<i>Cake forms</i> - Cookies, Cupcakes, or Sponge Cake\n" +
+            { Locale.English, "<color=#00ffff>New possible menu items:</color> <i>Desserts</i> - Cherry Pie, Apple Pie, Pumpkin Pie\n" +
+                $"{References.ColorTextHotDrinks} - Coffee, Coffee - Cake Stand (extra)\n" +
+                $"{References.ColorTextCakeFlavour} - Coffee\n" +
+                $"{References.ColorTextCakeForms} - Cookies, Cupcakes, or Sponge Cake. (Also includes the base recipe of Cake Batter)\n" +
                 "Adds one extra Mystery Ingredient Provider and one Mystery Tray Provider."
             }
         };
@@ -65,8 +75,9 @@ namespace KitchenMysteryMenu.Customs.Dishes
             (Locale.English, new UnlockInfo()
             {
                 Name = "Mystery - Coffee Cakes & Pies",
-                Description = "Adds Cherry Pie, Apple Pie, Pumpkin Pie, and Coffee as possible desserts.\n" +
-                "Also adds Coffee as a possible <color=pink>Cake</color> flavour, with the ability to make either Cookies, Cupcakes, or Sponge Cake.\n" +
+                Description = "Adds Cherry Pie, Apple Pie, Pumpkin Pie, and Coffee as possible desserts, with Cake Stand as a " +
+                $"possible extra for any {References.SpriteFillCoffee} Hot Drink.\n" +
+                $"Also adds Coffee as a possible {References.SpriteCake} Cake flavour, with the ability to make either Cookies, Cupcakes, or Sponge Cake.\n" +
                 "Provides one additional Mystery Ingredient Provider and one Mystery Tray Provider.",
                 FlavourText = ""
             })

--- a/Customs/Dishes/MysteryMenuCoffeeCakesPiesDish.cs
+++ b/Customs/Dishes/MysteryMenuCoffeeCakesPiesDish.cs
@@ -1,0 +1,79 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
+using KitchenMysteryMenu.Customs.Dishes.Desserts;
+using KitchenMysteryMenu.Customs.Appliances;
+using KitchenMysteryMenu.Customs.Dishes.Cakes;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuCoffeeCakesPiesDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Coffee Cakes and Pies";
+        public override DishType Type => DishType.Dessert;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients (normally requires flour, egg, sugar, [flavor]; 
+            GDOUtils.GetCastedGDO<Item, MysteryIngredientProviderCakes>(),
+            GDOUtils.GetCastedGDO<Item, MysteryTrayProviderCakes>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.CoffeeCup),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.MixingBowlEmpty)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.FillCoffee),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of Coffee, Coffee-flavored cookies, cupcakes, and sponge cakes, and Pies
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCakesCoffeeCookieDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color> <i>Desserts</i> - Cherry Pie, Apple Pie, Pumpkin Pie, Coffee\n" +
+                "<i>Cake flavour</i> - Coffee\n" +
+                "<i>Cake forms</i> - Cookies, Cupcakes, or Sponge Cake\n" +
+                "Adds one extra Mystery Ingredient Provider and one Mystery Tray Provider."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Coffee Cakes & Pies",
+                Description = "Adds Cherry Pie, Apple Pie, Pumpkin Pie, and Coffee as possible desserts.\n" +
+                "Also adds Coffee as a possible <color=pink>Cake</color> flavour, with the ability to make either Cookies, Cupcakes, or Sponge Cake.\n" +
+                "Provides one additional Mystery Ingredient Provider and one Mystery Tray Provider.",
+                FlavourText = ""
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuCondimentsDish.cs
+++ b/Customs/Dishes/MysteryMenuCondimentsDish.cs
@@ -55,7 +55,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Hot Dogs</i> - Extra Ketchup, Extra Mustard;  " +
                 "<i>Dumplings</i> - Soy Sauce;  <i>Stir Fry</i> - Soy Sauce\n" +
-                "Adds one extra Mystery Provider."
+                "Adds one extra Mystery Ingredient Provider."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
+++ b/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
@@ -51,6 +51,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBroccoliCheeseSoupDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCarrotSoupDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryMeatSoupDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryPumpkinSoupDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTomatoSoupDish>(),
 
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceMushroomSauceDish>(),

--- a/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
+++ b/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
@@ -14,14 +14,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
 
 namespace KitchenMysteryMenu.Customs.Dishes
 {
-    public class MysteryMenuSaucesDish : GenericMysteryDishCard
+    public class MysteryMenuSaucesSoupsDish : GenericMysteryDishCard
     {
-        protected override string NameTag => "Sauces";
+        protected override string NameTag => "Sauces and Soups";
         public override DishType Type => DishType.Extra;
-        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
         public override bool IsUnlockable => true;
@@ -47,6 +48,8 @@ namespace KitchenMysteryMenu.Customs.Dishes
         public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
         {
             // Add the Mystery versions of every sauce
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBroccoliCheeseSoupDish>(),
+
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceMushroomSauceDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceRedWineJusDish>(),
 
@@ -68,7 +71,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Sauces",
+                Name = "Mystery - Sauces & Soups",
                 Description = "Adds Mushroom Sauce and Red Wine Jus as possible Extras for Steaks, Gravy and Cranberry Sauce " +
                 "as possible Extras for Turkey, and Bolognese Sauce and Cheesy Spaghetti as alternative Mains with Spaghetti.\n" +
                 "Provides two additional Mystery Ingredient Providers.",

--- a/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
+++ b/Customs/Dishes/MysteryMenuSaucesSoupsDish.cs
@@ -49,6 +49,9 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             // Add the Mystery versions of every sauce
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryBroccoliCheeseSoupDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryCarrotSoupDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryMeatSoupDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTomatoSoupDish>(),
 
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceMushroomSauceDish>(),
             (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakSauceRedWineJusDish>(),
@@ -64,7 +67,8 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Any Steak</i> - Mushroom Sauce" +
                 ", Red Wine Jus;  <i>Turkey</i> - Gravy, Cranberry Sauce;  <i>Spaghetti</i> - Bolognese, Cheesy Spaghetti\n" +
-                "Adds two extra Mystery Providers."
+                "<i>Starters</i> - Broccoli Cheese Soup, Carrot Soup, Meat Soup, Tomato Soup\n" +
+                "Adds two extra Mystery Ingredient Providers."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
@@ -74,6 +78,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
                 Name = "Mystery - Sauces & Soups",
                 Description = "Adds Mushroom Sauce and Red Wine Jus as possible Extras for Steaks, Gravy and Cranberry Sauce " +
                 "as possible Extras for Turkey, and Bolognese Sauce and Cheesy Spaghetti as alternative Mains with Spaghetti.\n" +
+                "Also adds Broccoli Cheese Soup, Carrot Soup, Meat Soup, and Tomato Soup as possible starters.\n" +
                 "Provides two additional Mystery Ingredient Providers.",
                 FlavourText = ""
             })

--- a/Customs/Dishes/MysteryMenuSidesDish.cs
+++ b/Customs/Dishes/MysteryMenuSidesDish.cs
@@ -1,0 +1,81 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu;
+using KitchenMysteryMenu.Customs.Dishes.Steaks;
+using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Customs.Ingredients;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
+using KitchenMysteryMenu.Customs.Dishes.Desserts;
+using KitchenMysteryMenu.Customs.Dishes.Sides;
+
+namespace KitchenMysteryMenu.Customs.Dishes
+{
+    public class MysteryMenuSidesDish : GenericMysteryDishCard
+    {
+        protected override string NameTag => "Sides";
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => true;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 3;
+        public override HashSet<Item> MinimumIngredients => new()
+        {
+            // Add X Mystery Ingredients
+            GDOUtils.GetCastedGDO<Item, MysteryPotato>(),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot)
+        };
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven)
+        };
+
+        public override HashSet<GenericMysteryDish> ContainedMysteryRecipes => new()
+        {
+            // Add the Mystery versions of all sides
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideBambooDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideBroccoliDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideChipsDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideCornOnCobDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideMashedPotatoDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideOnionRingsDish>(),
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySideRoastPotatoDish>(),
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English, "<color=#00ffff>New possible menu items:</color>  <i>Sides</i> - Bamboo, Broccoli, " +
+                "Chips, Corn on the Cob, Mashed Potato, Onion Rings, Roast Potato\n" +
+                "Adds one extra Mystery Ingredient Provider."
+            }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Sides",
+                Description = "Adds Bamboo, Broccoli, Chips, Corn on the Cob, Mashed Potato, Onion Rings, and Roast Potato " +
+                "as possible sides.\n" +
+                "Provides one additional Mystery Ingredient Provider.",
+                FlavourText = "Better hope for Metal Tables before Potatoes show up as a daily ingredient!"
+            })
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBaseMainsDish>()
+        };
+    }
+}

--- a/Customs/Dishes/MysteryMenuSidesDish.cs
+++ b/Customs/Dishes/MysteryMenuSidesDish.cs
@@ -24,7 +24,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
     {
         protected override string NameTag => "Sides";
         public override DishType Type => DishType.Side;
-        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
         public override bool IsUnlockable => true;

--- a/Customs/Dishes/MysteryMenuToppingsDish.cs
+++ b/Customs/Dishes/MysteryMenuToppingsDish.cs
@@ -74,7 +74,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color> Breakfast - Beans, Eggs, Tomato, Mushroom;" +
                 " Burger - Cheese, Tomato, Onion; Dumplings - Seaweed; Salad - Onion, Olives; Turkey - Stuffing\n" +
-                "Adds one extra Mystery Provider."
+                "Adds one extra Mystery Ingredient Provider."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/MysteryMenuToppingsDish.cs
+++ b/Customs/Dishes/MysteryMenuToppingsDish.cs
@@ -27,7 +27,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
     {
         protected override string NameTag => "Toppings";
         public override DishType Type => DishType.Extra;
-        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.LargeDecrease;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
         public override bool IsUnlockable => true;

--- a/Customs/Dishes/MysteryMenuVeggieVariationsDish.cs
+++ b/Customs/Dishes/MysteryMenuVeggieVariationsDish.cs
@@ -66,7 +66,7 @@ namespace KitchenMysteryMenu.Customs.Dishes
         {
             { Locale.English, "<color=#00ffff>New possible menu items:</color> Apple Salad, Potato Salad, Mushroom Pie, " +
                 "Veggie Pie, Nut Roast, Onion Pizza, Mushroom Pizza, Bamboo Stir Fry, Mushroom Stir Fry\n" +
-                "Adds two extra Mystery Providers."
+                "Adds two extra Mystery Ingredient Providers."
             }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()

--- a/Customs/Dishes/Salad/MysterySaladToppingOliveDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladToppingOliveDish.cs
@@ -55,5 +55,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>();
     }
 }

--- a/Customs/Dishes/Salad/MysterySaladToppingOnionDish.cs
+++ b/Customs/Dishes/Salad/MysterySaladToppingOnionDish.cs
@@ -55,5 +55,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Salad
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySaladBaseDish>();
     }
 }

--- a/Customs/Dishes/Sides/MysterySideBambooDish.cs
+++ b/Customs/Dishes/Sides/MysterySideBambooDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideBambooDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Bamboo";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Bamboo);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Bamboo\n" +
+                "Put bamboo in a pot with water then boil. Portion to provide cooked bamboo as a side with a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Bamboo",
+                Description = "Adds bamboo as a side when it is present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.BambooCooked),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BambooRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideBroccoliDish.cs
+++ b/Customs/Dishes/Sides/MysterySideBroccoliDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideBroccoliDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Broccoli";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Broccoli);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Broccoli\n" +
+                "Put broccoli in a pot with water then boil. Portion to provide broccoli as a side with a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Broccoli",
+                Description = "Adds broccoli as a side when it is present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.BroccoliServing),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideChipsDish.cs
+++ b/Customs/Dishes/Sides/MysterySideChipsDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideChipsDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Chips";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Chips);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Potato\n" +
+                "Chop a potato then cook. Serve as a side alongside a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Chips",
+                Description = "Adds chips as a side when it is present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ChipsCooked),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Potato)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideCornOnCobDish.cs
+++ b/Customs/Dishes/Sides/MysterySideCornOnCobDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideCornOnCobDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Corn On Cob";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CornOnCob);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Corn\n" +
+                "Portion to remove husk from ear of corn. Throw away the husk, and cook the corn cob. " +
+                "Serve as a side alongside a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Corn on the Cob",
+                Description = "Adds corn on the cob as a side when corn is present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.CornCooked),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.CornRaw)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideMashedPotatoDish.cs
+++ b/Customs/Dishes/Sides/MysterySideMashedPotatoDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideMashedPotatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Mashed Potato";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.MashedPotato);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Potato\n" +
+                "Add water and a whole potato to a pot and cook. Mash (chop) the potato in the pot. " +
+                "Portion a serving (up to 20 times) as a side alongside a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Mashed Potato",
+                Description = "Adds mashed potato as a side when potato is present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.BoiledPotatoServing),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Potato)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideOnionRingsDish.cs
+++ b/Customs/Dishes/Sides/MysterySideOnionRingsDish.cs
@@ -1,0 +1,62 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideOnionRingsDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Onion Rings";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.OnionRings);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Onion, Flour\n" +
+                "Chop an onion, then combine with flour and cook. Serve as a side alongside a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Onion Rings",
+                Description = "Adds onion rings as a side when onions and flour are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.OnionRingsCooked),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Sides/MysterySideRoastPotatoDish.cs
+++ b/Customs/Dishes/Sides/MysterySideRoastPotatoDish.cs
@@ -1,0 +1,61 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Sides
+{
+    public class MysterySideRoastPotatoDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Side - Roast Potato";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.RoastPotato);
+        public override DishType Type => DishType.Side;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Potato\n" +
+                "Cook a whole potato. Serve as a side alongside a main."}
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Side - Roast Potato",
+                Description = "Adds roast potato as a side when potatoes are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.RoastPotatoItem),
+                Phase = MenuPhase.Side,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Potato)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSidesDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Side;
+    }
+}

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiBologneseDish.cs
@@ -58,7 +58,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
     }
 }

--- a/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
+++ b/Customs/Dishes/Spaghetti/MysterySpaghettiCheesyDish.cs
@@ -60,7 +60,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Spaghetti
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
     }
 }

--- a/Customs/Dishes/Starters/MysteryBreadBoardDish.cs
+++ b/Customs/Dishes/Starters/MysteryBreadBoardDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    public class MysteryBreadBoardDish : GenericMysteryDish
     {
-        protected override string NameTag => "Pumpkin Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
+        protected override string NameTag => "Bread Boards";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BreadStarter);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
-                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
-                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Flour\n" +
+                "Knead (or add water) to flour to make dough, then bake. Portion two slices of bread onto " +
+                "a serving board as a Starter."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Pumpkin Soup",
-                Description = "Adds pumpkin soup as a starter when onion and pumpkins are present",
+                Name = "Mystery - Starter - Bread Board",
+                Description = "Adds bread boards as a starter when flour is present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,19 +44,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemGroupReferences.BreadStarterItem),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Flour)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Starter;
     }

--- a/Customs/Dishes/Starters/MysteryBroccoliCheeseSoupDish.cs
+++ b/Customs/Dishes/Starters/MysteryBroccoliCheeseSoupDish.cs
@@ -1,7 +1,7 @@
 ﻿using KitchenData;
-using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
 using KitchenMysteryMenu.Utils;
 using System;
 using System.Collections.Generic;
@@ -9,13 +9,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KitchenMysteryMenu.Customs.Dishes.Turkey
+namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryTurkeyGravyDish : GenericMysteryDish
+    public class MysteryBroccoliCheeseSoupDish : GenericMysteryDish
     {
-        protected override string NameTag => "Mystery Turkey Gravy Dish";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TurkeyGravy);
-        public override DishType Type => DishType.Extra;
+        protected override string NameTag => "Broccoli Cheese Soup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BroccoliCheeseSoup);
+        public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
@@ -27,37 +27,39 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredient:</color> Onion, Turkey\n" + 
-                "Cook onion in a pot of water to make broth. Add a turkey carcass to the broth and cook again.\n" +
-                "Plate with  <i>Turkey</i>." }
+                "<color=yellow>Requires ingredients:</color> Onion, Cheese, Broccoli\n" +
+                "Put onion into a pot with water and boil to make broth. Combine broth with broccoli and" +
+                "cheese, then cook again. Portion to serve as a Starter." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Turkey - Gravy",
-                Description = "Adds Gravy as an option for Turkey",
+                Name = "Mystery - Starter - Broccoli Cheese Soup",
+                Description = "Adds broccoli cheese soup as a starter when onion, cheese, and broccoli are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
-        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
-            new Dish.IngredientUnlock()
+            new()
             {
-                MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemGroupReferences.TurkeyPlated),
-                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.TurkeyGravy)
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupBroccoliCheese),
+                Phase = MenuPhase.Starter,
+                Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.TurkeyIngredient),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
-        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
-        public override MenuPhase MenuPhase => BaseMysteryDish.MenuPhase;
+        public override MenuPhase MenuPhase => MenuPhase.Starter;
     }
 }

--- a/Customs/Dishes/Starters/MysteryCarrotSoupDish.cs
+++ b/Customs/Dishes/Starters/MysteryCarrotSoupDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryBroccoliCheeseSoupDish : GenericMysteryDish
+    public class MysteryCarrotSoupDish : GenericMysteryDish
     {
-        protected override string NameTag => "Broccoli Cheese Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BroccoliCheeseSoup);
+        protected override string NameTag => "Carrot Soup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.CarrotSoup);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Cheese, Broccoli\n" +
-                "Put onion into a pot with water and boil to make broth. Combine broth with broccoli and" +
-                "cheese, then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Onion, Carrot\n" +
+                "Put onion into a pot with water and boil to make broth. Combine broth with carrot" +
+                "then cook again. Portion to serve as a Starter." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Broccoli Cheese Soup",
-                Description = "Adds broccoli cheese soup as a starter when onion, cheese, and broccoli are present",
+                Name = "Mystery - Starter - Carrot Soup",
+                Description = "Adds carrot soup as a starter when onion and carrots are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,7 +44,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupBroccoliCheese),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupCarrot),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
@@ -52,8 +52,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Starters/MysteryChristmasCrackersDish.cs
+++ b/Customs/Dishes/Starters/MysteryChristmasCrackersDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    public class MysteryChristmasCrackersDish : GenericMysteryDish
     {
-        protected override string NameTag => "Pumpkin Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
+        protected override string NameTag => "Christmas Crackers";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Cracker);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,15 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
-                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
-                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Christmas Crackers\n" +
+                "Serve a Christmas Cracker as a Starter."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Pumpkin Soup",
-                Description = "Adds pumpkin soup as a starter when onion and pumpkins are present",
+                Name = "Mystery - Starter - Christmas Crackers",
+                Description = "Adds Christmas crackers as a starter when they are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,19 +43,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ChristmasCracker),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.ChristmasCracker)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Starter;
     }

--- a/Customs/Dishes/Starters/MysteryMandarinStarterDish.cs
+++ b/Customs/Dishes/Starters/MysteryMandarinStarterDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    public class MysteryMandarinStarterDish : GenericMysteryDish
     {
-        protected override string NameTag => "Pumpkin Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
+        protected override string NameTag => "Mandarin";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.Mandarin);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,15 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
-                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
-                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Mandarins\n" +
+                "Portion 2 or 4 slices of Mandarin as a Starter."}
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Pumpkin Soup",
-                Description = "Adds pumpkin soup as a starter when onion and pumpkins are present",
+                Name = "Mystery - Starter - Mandarins",
+                Description = "Adds mandarins as a starter when they are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,19 +43,24 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.MandarinSlices2Serving),
+                Phase = MenuPhase.Starter,
+                Weight = 1
+            },
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.MandarinSlices4Serving),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.MandarinRaw)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Starter;
     }

--- a/Customs/Dishes/Starters/MysteryMeatSoupDish.cs
+++ b/Customs/Dishes/Starters/MysteryMeatSoupDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryBroccoliCheeseSoupDish : GenericMysteryDish
+    public class MysteryMeatSoupDish : GenericMysteryDish
     {
-        protected override string NameTag => "Broccoli Cheese Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BroccoliCheeseSoup);
+        protected override string NameTag => "Meat Soup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.MeatSoup);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Cheese, Broccoli\n" +
-                "Put onion into a pot with water and boil to make broth. Combine broth with broccoli and" +
-                "cheese, then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Onion, Meat\n" +
+                "Put onion into a pot with water and boil to make broth. Combine broth with meat" +
+                "then cook again. Portion to serve as a Starter." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Broccoli Cheese Soup",
-                Description = "Adds broccoli cheese soup as a starter when onion, cheese, and broccoli are present",
+                Name = "Mystery - Starter - Meat Soup",
+                Description = "Adds meat soup as a starter when onion and meat are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,7 +44,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupBroccoliCheese),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupMeat),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
@@ -52,8 +52,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Starters/MysteryPumpkinSeedDish.cs
+++ b/Customs/Dishes/Starters/MysteryPumpkinSeedDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    public class MysteryPumpkinSeedDish : GenericMysteryDish
     {
-        protected override string NameTag => "Pumpkin Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
+        protected override string NameTag => "Pumpkin Seeds";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSeed);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
-                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
-                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Pumpkin\n" +
+                "Portion to remove the seeds, then cook. Serve as a Starter. " +
+                "Throw out the hollow pumpkin (or use in another dish)." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Pumpkin Soup",
-                Description = "Adds pumpkin soup as a starter when onion and pumpkins are present",
+                Name = "Mystery - Starter - Pumpkin Seeds",
+                Description = "Adds pumpkin seeds as a starter when pumpkins are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,19 +44,18 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PumpkinSeedsRoasted),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuBoardsTreatsDish>()
         };
         public override MenuPhase MenuPhase => MenuPhase.Starter;
     }

--- a/Customs/Dishes/Starters/MysteryPumpkinSoupDish.cs
+++ b/Customs/Dishes/Starters/MysteryPumpkinSoupDish.cs
@@ -1,0 +1,63 @@
+﻿using KitchenData;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Dishes.Turkey;
+using KitchenMysteryMenu.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KitchenMysteryMenu.Customs.Dishes.Starters
+{
+    public class MysteryPumpkinSoupDish : GenericMysteryDish
+    {
+        protected override string NameTag => "Pumpkin Soup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.PumpkinSoup);
+        public override DishType Type => DishType.Starter;
+        public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
+        public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
+        public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
+        public override bool IsUnlockable => false;
+        public override bool RequiredNoDishItem => true;
+        public override bool IsAvailableAsLobbyOption => false;
+        public override int Difficulty => 2;
+        public override Dictionary<Locale, string> Recipe => new()
+        {
+            { Locale.English,
+                "<color=yellow>Requires ingredients:</color> Onion, Pumpkin\n" +
+                "Put onion into a pot with water and boil to make broth. Portion to remove the seeds, then chop the hollow pumpkin. " +
+                "Combine broth with chopped pumpkin then cook again. Portion to serve as a Starter." }
+        };
+        public override List<(Locale, UnlockInfo)> InfoList => new()
+        {
+            (Locale.English, new UnlockInfo()
+            {
+                Name = "Mystery - Starter - Pumpkin Soup",
+                Description = "Adds pumpkin soup as a starter when onion and tomatoes are present",
+                FlavourText = $"{References.DishCardDoNotAddFlavorText}"
+            })
+        };
+
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
+        {
+            new()
+            {
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupPumpkin),
+                Phase = MenuPhase.Starter,
+                Weight = 1
+            }
+        };
+        public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
+        {
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Pumpkin)
+        };
+        public override List<Unlock> HardcodedRequirements => new()
+        {
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
+        };
+        public override MenuPhase MenuPhase => MenuPhase.Starter;
+    }
+}

--- a/Customs/Dishes/Starters/MysteryTomatoSoupDish.cs
+++ b/Customs/Dishes/Starters/MysteryTomatoSoupDish.cs
@@ -11,10 +11,10 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMenu.Customs.Dishes.Starters
 {
-    public class MysteryBroccoliCheeseSoupDish : GenericMysteryDish
+    public class MysteryTomatoSoupDish : GenericMysteryDish
     {
-        protected override string NameTag => "Broccoli Cheese Soup";
-        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.BroccoliCheeseSoup);
+        protected override string NameTag => "Tomato Soup";
+        public override Dish OrigDish => (Dish)GDOUtils.GetExistingGDO(DishReferences.TomatoSoup);
         public override DishType Type => DishType.Starter;
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.None;
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.None;
@@ -26,16 +26,16 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English,
-                "<color=yellow>Requires ingredients:</color> Onion, Cheese, Broccoli\n" +
-                "Put onion into a pot with water and boil to make broth. Combine broth with broccoli and" +
-                "cheese, then cook again. Portion to serve as a Starter." }
+                "<color=yellow>Requires ingredients:</color> Onion, Tomato\n" +
+                "Put onion into a pot with water and boil to make broth. Chop a tomato twice to make sauce." +
+                "Combine broth with tomato sauce and another tomato then cook again. Portion to serve as a Starter." }
         };
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo()
             {
-                Name = "Mystery - Starter - Broccoli Cheese Soup",
-                Description = "Adds broccoli cheese soup as a starter when onion, cheese, and broccoli are present",
+                Name = "Mystery - Starter - Tomato Soup",
+                Description = "Adds tomato soup as a starter when onion and tomatoes are present",
                 FlavourText = $"{References.DishCardDoNotAddFlavorText}"
             })
         };
@@ -44,7 +44,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         {
             new()
             {
-                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupBroccoliCheese),
+                Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.ServedSoupTomato),
                 Phase = MenuPhase.Starter,
                 Weight = 1
             }
@@ -52,8 +52,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Starters
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Onion),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Cheese)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Tomato)
         };
         public override List<Unlock> HardcodedRequirements => new()
         {

--- a/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
@@ -72,5 +72,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceMushroomSauceDish.cs
@@ -70,9 +70,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
-        public override GenericMysteryDish BaseMysteryDish =>
-            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
@@ -72,5 +72,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakSauceRedWineJusDish.cs
@@ -70,9 +70,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
-        public override GenericMysteryDish BaseMysteryDish =>
-            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakToppingMushroomDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakToppingMushroomDish.cs
@@ -70,5 +70,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/Steaks/MysterySteakToppingTomatoDish.cs
+++ b/Customs/Dishes/Steaks/MysterySteakToppingTomatoDish.cs
@@ -70,5 +70,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.Steaks
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysterySteakBaseDish>();
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
@@ -53,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BambooRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BambooRaw),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBambooDish.cs
@@ -56,5 +56,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             (Item) GDOUtils.GetExistingGDO(ItemReferences.BambooRaw),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
+        public override GenericMysteryDish BaseMysteryDish =>
+            (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryBroccoliDish.cs
@@ -53,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.BroccoliRaw),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
         public override bool RequiresVariant => false;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();

--- a/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryCarrotDish.cs
@@ -53,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Carrot),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
         public override bool RequiresVariant => false;
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish) GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();

--- a/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
@@ -48,7 +48,7 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             new()
             {
                 MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.StirFryPlated),
-                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChoppedContainerCooked)
+                Ingredient = (Item)GDOUtils.GetExistingGDO(ItemReferences.MushroomCookedWrapped)
             }
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()

--- a/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
@@ -53,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFryMushroomDish.cs
@@ -56,5 +56,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Mushroom),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySoySauceDish.cs
@@ -55,5 +55,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuCondimentsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
@@ -53,7 +53,8 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
         };
         public override HashSet<Item> MinimumRequiredMysteryIngredients => new HashSet<Item>()
         {
-            (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat)
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat),
+            (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
     }
 }

--- a/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
+++ b/Customs/Dishes/StirFry/MysteryStirFrySteakDish.cs
@@ -56,5 +56,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.StirFry
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Meat),
             (Item) GDOUtils.GetExistingGDO(ItemReferences.Rice)
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryStirFryBaseDish>();
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
@@ -55,8 +55,9 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         };
         public override List<Unlock> HardcodedRequirements => new()
         {
-            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
+            GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesSoupsDish>()
         };
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
+        public override MenuPhase MenuPhase => BaseMysteryDish.MenuPhase;
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyCranberrySauceDish.cs
@@ -57,5 +57,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyGravyDish.cs
@@ -57,5 +57,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuSaucesDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
@@ -58,5 +58,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
         {
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
+        public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
     }
 }

--- a/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
+++ b/Customs/Dishes/Turkey/MysteryTurkeyStuffingDish.cs
@@ -59,5 +59,6 @@ namespace KitchenMysteryMenu.Customs.Dishes.Turkey
             GDOUtils.GetCastedGDO<Dish, MysteryMenuToppingsDish>()
         };
         public override GenericMysteryDish BaseMysteryDish => (GenericMysteryDish)GDOUtils.GetCustomGameDataObject<MysteryTurkeyBaseDish>();
+        public override MenuPhase MenuPhase => BaseMysteryDish.MenuPhase;
     }
 }

--- a/Customs/Ingredients/MysteryChocolate.cs
+++ b/Customs/Ingredients/MysteryChocolate.cs
@@ -12,10 +12,10 @@ using UnityEngine;
 
 namespace KitchenMysteryMenu.Customs.Ingredients
 {
-    public class MysteryCookieTray : GenericMysteryItem
+    public class MysteryChocolate : GenericMysteryItem
     {
-        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.CookieTray);
-        protected override string NameTag => "Cookie Tray";
-        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryTrayProviderCakes>();
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Chocolate);
+        protected override string NameTag => "Mystery Chocolate";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderCakes2>();
     }
 }

--- a/Customs/Ingredients/MysteryCookieTray.cs
+++ b/Customs/Ingredients/MysteryCookieTray.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryCookieTray : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.CookieTray);
+        protected override string NameTag => "Cookie Tray";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderBoard>();
+    }
+}

--- a/Customs/Ingredients/MysteryIceCreamStrawberry C.cs
+++ b/Customs/Ingredients/MysteryIceCreamStrawberry C.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysterySugar : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Sugar);
+        protected override string NameTag => "Sugar";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderCakes>();
+    }
+}

--- a/Customs/Ingredients/MysteryIceCreamStrawberry.cs
+++ b/Customs/Ingredients/MysteryIceCreamStrawberry.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryIceCreamStrawberry : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.IceCreamStrawberry);
+        protected override string NameTag => "Strawberry Ice Cream Scoop";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderBoard>();
+    }
+}

--- a/Customs/Ingredients/MysteryIceCreamVanilla.cs
+++ b/Customs/Ingredients/MysteryIceCreamVanilla.cs
@@ -1,0 +1,21 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryIceCreamVanilla : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.IceCreamVanilla);
+        protected override string NameTag => "Vanilla Ice Cream Scoop";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderBoard2>();
+    }
+}

--- a/Customs/Ingredients/MysteryPotato.cs
+++ b/Customs/Ingredients/MysteryPotato.cs
@@ -1,0 +1,36 @@
+﻿using KitchenData;
+using KitchenLib.Customs;
+using KitchenLib.References;
+using KitchenLib.Utils;
+using KitchenMysteryMenu.Customs.Appliances;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KitchenMysteryMenu.Customs.Ingredients
+{
+    public class MysteryPotato : GenericMysteryItem
+    {
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.Potato);
+        protected override string NameTag => "Mystery Potato";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderSides>();
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        {
+            new()
+            {
+                Duration = 3f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Chop),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.PotatoChopped)
+            },
+            new()
+            {
+                Duration = 4f,
+                Process = (Process) GDOUtils.GetExistingGDO(ProcessReferences.Cook),
+                Result = (Item) GDOUtils.GetExistingGDO(ItemReferences.RoastPotatoItem)
+            }
+        };
+    }
+}

--- a/Customs/Ingredients/MysteryTeapot.cs
+++ b/Customs/Ingredients/MysteryTeapot.cs
@@ -12,10 +12,10 @@ using UnityEngine;
 
 namespace KitchenMysteryMenu.Customs.Ingredients
 {
-    public class MysteryCookieTray : GenericMysteryItem
+    public class MysteryTeapot : GenericMysteryItem
     {
-        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.CookieTray);
-        protected override string NameTag => "Cookie Tray";
-        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryTrayProviderCakes>();
+        public override Item ExistingGDO => (Item)GDOUtils.GetExistingGDO(ItemReferences.TeaPot);
+        protected override string NameTag => "Mystery Teapot";
+        public override Appliance DedicatedProvider => GDOUtils.GetCastedGDO<Appliance, MysteryIngredientProviderCakes3>();
     }
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -6,6 +6,7 @@ using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Desserts;
 using KitchenMysteryMenu.Customs.Dishes.Dumplings;
 using KitchenMysteryMenu.Customs.Dishes.Fish;
 using KitchenMysteryMenu.Customs.Dishes.HotDog;
@@ -65,6 +66,8 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProvider>();
             AddGameDataObject<MysteryIngredientProvider2>();
             AddGameDataObject<MysteryIngredientProviderExtra>();
+            AddGameDataObject<MysteryIngredientProviderBoard>();
+            AddGameDataObject<MysteryIngredientProviderBoard2>();
             AddGameDataObject<MysteryIngredientProviderExtra2>();
             AddGameDataObject<MysteryIngredientProviderExtra3>();
             AddGameDataObject<MysteryIngredientProviderExtra4>();
@@ -79,6 +82,8 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryApple>();
             AddGameDataObject<MysteryCheese>();
             AddGameDataObject<MysteryFlour>();
+            AddGameDataObject<MysteryIceCreamStrawberry>();
+            AddGameDataObject<MysteryIceCreamVanilla>();
             AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryMushroom>();
             AddGameDataObject<MysteryOnion>();
@@ -99,6 +104,7 @@ namespace KitchenMysteryMenu
         {
             // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();
+            AddGameDataObject<MysteryMenuBoardsTreatsDish>();
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesSoupsDish>();
@@ -106,11 +112,22 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMenuVeggieVariationsDish>();
 
             // Mystery Starters
+            AddGameDataObject<MysteryBreadBoardDish>();
             AddGameDataObject<MysteryBroccoliCheeseSoupDish>();
             AddGameDataObject<MysteryCarrotSoupDish>();
+            AddGameDataObject<MysteryChristmasCrackersDish>();
+            AddGameDataObject<MysteryMandarinStarterDish>();
             AddGameDataObject<MysteryMeatSoupDish>();
+            AddGameDataObject<MysteryPumpkinSeedDish>();
             AddGameDataObject<MysteryPumpkinSoupDish>();
             AddGameDataObject<MysteryTomatoSoupDish>();
+
+            // Mystery Desserts
+            AddGameDataObject<MysteryCheeseBoardDish>();
+            AddGameDataObject<MysteryIceCreamChocolateDish>();
+            AddGameDataObject<MysteryIceCreamServingDish>();
+            AddGameDataObject<MysteryIceCreamStrawberryDish>();
+            AddGameDataObject<MysteryIceCreamVanillaDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -13,6 +13,7 @@ using KitchenMysteryMenu.Customs.Dishes.HotDog;
 using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Pizza;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
+using KitchenMysteryMenu.Customs.Dishes.Sides;
 using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
 using KitchenMysteryMenu.Customs.Dishes.Starters;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
@@ -74,6 +75,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra5>();
             AddGameDataObject<MysteryIngredientProviderExtra6>();
             AddGameDataObject<MysteryIngredientProviderExtra7>();
+            AddGameDataObject<MysteryIngredientProviderSides>();
         }
 
         private void AddIngredientGDOs()
@@ -87,6 +89,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMeat>();
             AddGameDataObject<MysteryMushroom>();
             AddGameDataObject<MysteryOnion>();
+            AddGameDataObject<MysteryPotato>();
             AddGameDataObject<MysterySoySauce>();
             AddGameDataObject<MysterySurfNTurf>();
             AddGameDataObject<MysteryWine>();
@@ -108,6 +111,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesSoupsDish>();
+            AddGameDataObject<MysteryMenuSidesDish>();
             AddGameDataObject<MysteryMenuToppingsDish>();
             AddGameDataObject<MysteryMenuVeggieVariationsDish>();
 
@@ -121,6 +125,15 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryPumpkinSeedDish>();
             AddGameDataObject<MysteryPumpkinSoupDish>();
             AddGameDataObject<MysteryTomatoSoupDish>();
+
+            // Mystery Sides
+            AddGameDataObject<MysterySideBambooDish>();
+            AddGameDataObject<MysterySideBroccoliDish>();
+            AddGameDataObject<MysterySideChipsDish>();
+            AddGameDataObject<MysterySideCornOnCobDish>();
+            AddGameDataObject<MysterySideMashedPotatoDish>();
+            AddGameDataObject<MysterySideOnionRingsDish>();
+            AddGameDataObject<MysterySideRoastPotatoDish>();
 
             // Mystery Desserts
             AddGameDataObject<MysteryCheeseBoardDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -107,6 +107,9 @@ namespace KitchenMysteryMenu
 
             // Mystery Starters
             AddGameDataObject<MysteryBroccoliCheeseSoupDish>();
+            AddGameDataObject<MysteryCarrotSoupDish>();
+            AddGameDataObject<MysteryMeatSoupDish>();
+            AddGameDataObject<MysteryTomatoSoupDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -109,6 +109,7 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryBroccoliCheeseSoupDish>();
             AddGameDataObject<MysteryCarrotSoupDish>();
             AddGameDataObject<MysteryMeatSoupDish>();
+            AddGameDataObject<MysteryPumpkinSoupDish>();
             AddGameDataObject<MysteryTomatoSoupDish>();
 
             // Mystery Breakfast Dishes

--- a/Mod.cs
+++ b/Mod.cs
@@ -6,6 +6,8 @@ using KitchenMysteryMenu.Customs.Appliances;
 using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Customs.Dishes.Breakfast;
 using KitchenMysteryMenu.Customs.Dishes.Burger;
+using KitchenMysteryMenu.Customs.Dishes.Cakes;
+using KitchenMysteryMenu.Customs.Dishes.Coffee;
 using KitchenMysteryMenu.Customs.Dishes.Desserts;
 using KitchenMysteryMenu.Customs.Dishes.Dumplings;
 using KitchenMysteryMenu.Customs.Dishes.Fish;
@@ -69,6 +71,9 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra>();
             AddGameDataObject<MysteryIngredientProviderBoard>();
             AddGameDataObject<MysteryIngredientProviderBoard2>();
+            AddGameDataObject<MysteryIngredientProviderCakes>();
+            AddGameDataObject<MysteryIngredientProviderCakes2>();
+            AddGameDataObject<MysteryIngredientProviderCakes3>();
             AddGameDataObject<MysteryIngredientProviderExtra2>();
             AddGameDataObject<MysteryIngredientProviderExtra3>();
             AddGameDataObject<MysteryIngredientProviderExtra4>();
@@ -76,13 +81,14 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryIngredientProviderExtra6>();
             AddGameDataObject<MysteryIngredientProviderExtra7>();
             AddGameDataObject<MysteryIngredientProviderSides>();
+            AddGameDataObject<MysteryTrayProviderCakes>();
         }
 
         private void AddIngredientGDOs()
         {
-            // For the HQ Kitchen to work with minimal extra code
             AddGameDataObject<MysteryApple>();
             AddGameDataObject<MysteryCheese>();
+            AddGameDataObject<MysteryChocolate>();
             AddGameDataObject<MysteryFlour>();
             AddGameDataObject<MysteryIceCreamStrawberry>();
             AddGameDataObject<MysteryIceCreamVanilla>();
@@ -90,9 +96,13 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMushroom>();
             AddGameDataObject<MysteryOnion>();
             AddGameDataObject<MysteryPotato>();
+            AddGameDataObject<MysterySugar>();
             AddGameDataObject<MysterySoySauce>();
             AddGameDataObject<MysterySurfNTurf>();
+            AddGameDataObject<MysteryTeapot>();
             AddGameDataObject<MysteryWine>();
+
+            AddGameDataObject<MysteryCookieTray>();
         }
 
         private void AddItemGroupGDOs()
@@ -108,6 +118,8 @@ namespace KitchenMysteryMenu
             // Mystery Dish cards
             AddGameDataObject<MysteryMenuBaseMainsDish>();
             AddGameDataObject<MysteryMenuBoardsTreatsDish>();
+            AddGameDataObject<MysteryMenuCoffeeCakesPiesDish>();
+            AddGameDataObject<MysteryMenuCoffeeCakeVarietyDish>();
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
             AddGameDataObject<MysteryMenuSaucesSoupsDish>();
@@ -136,11 +148,14 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysterySideRoastPotatoDish>();
 
             // Mystery Desserts
+            AddGameDataObject<MysteryApplePieDish>();
             AddGameDataObject<MysteryCheeseBoardDish>();
+            AddGameDataObject<MysteryCherryPieDish>();
             AddGameDataObject<MysteryIceCreamChocolateDish>();
             AddGameDataObject<MysteryIceCreamServingDish>();
             AddGameDataObject<MysteryIceCreamStrawberryDish>();
             AddGameDataObject<MysteryIceCreamVanillaDish>();
+            AddGameDataObject<MysteryPumpkinPieDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();
@@ -154,6 +169,27 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryBurgerToppingCheeseDish>();
             AddGameDataObject<MysteryBurgerToppingOnionDish>();
             AddGameDataObject<MysteryBurgerToppingTomatoDish>();
+
+            // Mystery Cakes Dishes
+            AddGameDataObject<MysteryCakeBatterRecipe>();
+            AddGameDataObject<MysteryCakesCoffeeCookieDish>();
+            AddGameDataObject<MysteryCakesCoffeeCupcakeDish>();
+            AddGameDataObject<MysteryCakesCoffeeSpongeCakeDish>();
+            AddGameDataObject<MysteryCakesChocolateCookieDish>();
+            AddGameDataObject<MysteryCakesChocolateCupcakeDish>();
+            AddGameDataObject<MysteryCakesChocolateSpongeCakeDish>();
+            AddGameDataObject<MysteryCakesLemonCookieDish>();
+            AddGameDataObject<MysteryCakesLemonCupcakeDish>();
+            AddGameDataObject<MysteryCakesLemonSpongeCakeDish>();
+
+            // Mystery Cakes Dishes
+            AddGameDataObject<MysteryCoffeeBaseDish>();
+            AddGameDataObject<MysteryCoffeeCakeStandDish>();
+            AddGameDataObject<MysteryCoffeeExtraMilkDish>();
+            AddGameDataObject<MysteryCoffeeExtraSugarDish>();
+            AddGameDataObject<MysteryCoffeeIcedDish>();
+            AddGameDataObject<MysteryCoffeeLatteDish>();
+            AddGameDataObject<MysteryTeaDish>();
 
             // Mystery Dumplings Dishes
             AddGameDataObject<MysteryDumplingsBaseDish>();

--- a/Mod.cs
+++ b/Mod.cs
@@ -13,6 +13,7 @@ using KitchenMysteryMenu.Customs.Dishes.Pies;
 using KitchenMysteryMenu.Customs.Dishes.Pizza;
 using KitchenMysteryMenu.Customs.Dishes.Salad;
 using KitchenMysteryMenu.Customs.Dishes.Spaghetti;
+using KitchenMysteryMenu.Customs.Dishes.Starters;
 using KitchenMysteryMenu.Customs.Dishes.Steaks;
 using KitchenMysteryMenu.Customs.Dishes.StirFry;
 using KitchenMysteryMenu.Customs.Dishes.Turkey;
@@ -100,9 +101,12 @@ namespace KitchenMysteryMenu
             AddGameDataObject<MysteryMenuBaseMainsDish>();
             AddGameDataObject<MysteryMenuCarnivoreVariationsDish>();
             AddGameDataObject<MysteryMenuCondimentsDish>();
-            AddGameDataObject<MysteryMenuSaucesDish>();
+            AddGameDataObject<MysteryMenuSaucesSoupsDish>();
             AddGameDataObject<MysteryMenuToppingsDish>();
             AddGameDataObject<MysteryMenuVeggieVariationsDish>();
+
+            // Mystery Starters
+            AddGameDataObject<MysteryBroccoliCheeseSoupDish>();
 
             // Mystery Breakfast Dishes
             AddGameDataObject<MysteryBreakfastBaseDish>();

--- a/MysteryMenu.csproj
+++ b/MysteryMenu.csproj
@@ -23,8 +23,4 @@
 	<ItemGroup>
 		<PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.10.21" />
 	</ItemGroup>
-  
-	<ItemGroup>
-	  <Folder Include="Customs\Dishes\Coffee\" />
-	</ItemGroup>
 </Project>

--- a/MysteryMenu.csproj
+++ b/MysteryMenu.csproj
@@ -23,4 +23,8 @@
 	<ItemGroup>
 		<PackageReference Include="Yariazen.PlateUp.ModBuildUtilities" Version="1.10.21" />
 	</ItemGroup>
+  
+	<ItemGroup>
+	  <Folder Include="Customs\Dishes\Coffee\" />
+	</ItemGroup>
 </Project>

--- a/Systems/HandleNewMysteryMenuDish.cs
+++ b/Systems/HandleNewMysteryMenuDish.cs
@@ -80,7 +80,9 @@ namespace KitchenMysteryMenu.Systems
             Mod.Logger.LogInfo("Handling new menu item");
             using var nonHandledMenuItems = NonHandledMenuItems.ToEntityArray(Allocator.Temp);
             using var cMenuItems = NonHandledMenuItems.ToComponentDataArray<CMenuItem>(Allocator.Temp);
-            for (int i = 0; i < nonHandledMenuItems.Length; i++)
+            int matchCount = 0;
+            int matchMax = dishData.UnlocksMenuItems.Count;
+            for (int i = 0; i < nonHandledMenuItems.Length && matchCount < matchMax; i++)
             {
                 var entity = nonHandledMenuItems[i];
                 var menuItem = cMenuItems[i];
@@ -145,6 +147,7 @@ namespace KitchenMysteryMenu.Systems
                     Type = type,
                     HasBeenProvided = false
                 });
+                matchCount++;
             }
         }
 

--- a/Systems/HandleNewMysteryMenuDish.cs
+++ b/Systems/HandleNewMysteryMenuDish.cs
@@ -145,7 +145,6 @@ namespace KitchenMysteryMenu.Systems
                     Type = type,
                     HasBeenProvided = false
                 });
-                break;
             }
         }
 

--- a/Systems/RemoveMysteryMenuProvidersAtNight.cs
+++ b/Systems/RemoveMysteryMenuProvidersAtNight.cs
@@ -35,7 +35,8 @@ namespace KitchenMysteryMenu.Systems
 
             for (int i = 0; i < providerEntities.Length; i++)
             {
-                if (providerMysteryProviders[i].Type == MysteryMenuType.Mystery)
+                if (providerMysteryProviders[i].Type == MysteryMenuType.Mystery || 
+                    providerMysteryProviders[i].Type == MysteryMenuType.MysteryTray)
                 {
                     // This probably makes more sense when the prefab is set up properly. For now, just do it the same way.
                     var cItemProvider = providerItemProviders[i];
@@ -43,6 +44,10 @@ namespace KitchenMysteryMenu.Systems
                     // Issue #5: empty out the items from the providers so that they can't be used to determine what static ingredients
                     //      are available or not when new static dish cards are selected. Might want to revert it to the default instead?
                     cItemProvider.SetAsItem(0);
+                    if (providerMysteryProviders[i].Type == MysteryMenuType.MysteryTray)
+                    {
+                        cItemProvider.AutoPlaceOnHolder = false;
+                    }
                     EntityManager.SetComponentData(providerEntities[i], cItemProvider);
                 }
             }

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -725,7 +725,11 @@ namespace KitchenMysteryMenu.Systems
                 // This is where we ensure that the parent recipes get added and accounted for
                 if (IsAvailableIngredient())
                 {
-                    int parentMissingIngredientSum = parentRecipes.SelectMany(r => r.MissingIngredients).ToHashSet().Count();
+                    // Only count ingredients that aren't in this recipe's missing ingredients to not double count, say, rice.
+                    HashSet<Item> parentMissingIngredients = parentRecipes.SelectMany(r => r.MissingIngredients)
+                        .Where(item => !MissingIngredients.Contains(item))
+                        .ToHashSet();
+                    int parentMissingIngredientSum = parentMissingIngredients.Count();
                     Mod.Logger.LogInfo($"{logKey} AvailableIngredient {{Recipe = {Recipe.UniqueNameID}, MenuItem = " +
                         $"{Recipe.IngredientsUnlocks.First(iu => iu.Ingredient.ID == DishOption.Ingredient && iu.MenuItem.ID == DishOption.MenuItem).MenuItem.name}," +
                         $" ParentRecipes = {parentRecipes}, ParentDistinctMissingIngredientSum = {parentMissingIngredientSum}}}");
@@ -734,7 +738,10 @@ namespace KitchenMysteryMenu.Systems
                 // Possible Extras always need their parent recipe to be "Could Be Served", and as such
                 if (IsPossibleExtra())
                 {
-                    int parentMissingIngredientSum = parentRecipes.SelectMany(r => r.MissingIngredients).ToHashSet().Count();
+                    HashSet<Item> parentMissingIngredients = parentRecipes.SelectMany(r => r.MissingIngredients)
+                        .Where(item => !MissingIngredients.Contains(item))
+                        .ToHashSet();
+                    int parentMissingIngredientSum = parentMissingIngredients.Count();
                     Mod.Logger.LogInfo($"{logKey} PossibleExtra {{Recipe = {Recipe.UniqueNameID}, MenuItem = " +
                         $"{Recipe.ExtraOrderUnlocks.First(iu => iu.Ingredient.ID == DishExtra.Ingredient && iu.MenuItem.ID == DishExtra.MenuItem).MenuItem.name}," +
                         $" ParentRecipes = {parentRecipes}, ParentDistinctMissingIngredientSum = {parentMissingIngredientSum}}}");

--- a/Systems/SelectMysteryMenuOfDay.cs
+++ b/Systems/SelectMysteryMenuOfDay.cs
@@ -180,6 +180,9 @@ namespace KitchenMysteryMenu.Systems
                     }
                     var mysteryProviderCItemProvider = EntityManager.GetComponentData<CItemProvider>(mysteryProviderEntityList[mysteryProviderIndex]);
                     mysteryProviderCItemProvider.SetAsItem(ingredient.ID);
+                    mysteryProviderCItemProvider.PreventReturns = selectedRecipeList
+                        .Where(recipe => recipe.Recipe.MinimumRequiredMysteryIngredients.Contains(ingredient))
+                        .Any(recipe => recipe.Recipe.PreventIngredientReturns);
                     EntityManager.SetComponentData(mysteryProviderEntityList[mysteryProviderIndex], mysteryProviderCItemProvider);
                     availableItemsForRecipes.Add(ingredient);
                     mysteryProviderIndex++;

--- a/Utils/MysteryDishUtils.cs
+++ b/Utils/MysteryDishUtils.cs
@@ -22,6 +22,7 @@ namespace KitchenMysteryMenu.Utils
             ItemReferences.DoughnutTray,
             ItemReferences.CupcakeTray,
             ItemReferences.BigCakeTin,
+            ItemReferences.ExtraCakeStand,
             References.LasagneTray
         };
 
@@ -32,6 +33,7 @@ namespace KitchenMysteryMenu.Utils
             ItemReferences.CupcakeTray,
             ItemReferences.DoughnutTray,
             ItemReferences.BigCakeTin,
+            ItemReferences.ExtraCakeStand,
             References.LasagneTray
         };
 
@@ -43,6 +45,27 @@ namespace KitchenMysteryMenu.Utils
         public static bool IsTray(int providedItem)
         {
             return Trays.Contains(providedItem);
+        }
+
+        public static string ColorizeSpriteTextToCake(string innerStr)
+        {
+            return ColorizeSpriteText(innerStr, References.ColorCakeHex, References.SpriteCakeTint1);
+        }
+
+        public static string ColorizeSpriteTextToHotDrink(string innerStr)
+        {
+            return ColorizeSpriteText(innerStr, References.ColorHotDrinkHex, References.SpriteFillCoffeeTint1);
+        }
+
+        public static string ColorizeSpriteText(string innerStr, string color, string spriteStrWithTint)
+        {
+            string spriteAndTextStr = $"{spriteStrWithTint}{innerStr}";
+            return $"{ColorizeText(spriteAndTextStr, color)}";
+        }
+
+        public static string ColorizeText(string innerStr, string color)
+        {
+            return $"<color={color}>{innerStr}</color>";
         }
     }
 }

--- a/Utils/MysteryDishUtils.cs
+++ b/Utils/MysteryDishUtils.cs
@@ -20,12 +20,29 @@ namespace KitchenMysteryMenu.Utils
             ItemReferences.CookieTray,
             ItemReferences.BrownieTray,
             ItemReferences.DoughnutTray,
-            ItemReferences.BigCakeTin
+            ItemReferences.CupcakeTray,
+            ItemReferences.BigCakeTin,
+            References.LasagneTray
+        };
+
+        private static HashSet<int> Trays = new HashSet<int>()
+        {
+            ItemReferences.CookieTray,
+            ItemReferences.BrownieTray,
+            ItemReferences.CupcakeTray,
+            ItemReferences.DoughnutTray,
+            ItemReferences.BigCakeTin,
+            References.LasagneTray
         };
 
         public static bool IsLimitedContainer(int providedItem)
         {
             return ReusableItems.Contains(providedItem);
+        }
+
+        public static bool IsTray(int providedItem)
+        {
+            return Trays.Contains(providedItem);
         }
     }
 }

--- a/Utils/MysteryMenuType.cs
+++ b/Utils/MysteryMenuType.cs
@@ -10,6 +10,7 @@ namespace KitchenMysteryMenu.Utils
     {
         Static = 0,
         Fish = 1,
-        Mystery = 2
+        Mystery = 2,
+        MysteryPan = 3
     }
 }

--- a/Utils/MysteryMenuType.cs
+++ b/Utils/MysteryMenuType.cs
@@ -11,6 +11,6 @@ namespace KitchenMysteryMenu.Utils
         Static = 0,
         Fish = 1,
         Mystery = 2,
-        MysteryPan = 3
+        MysteryTray = 3
     }
 }

--- a/Utils/References.cs
+++ b/Utils/References.cs
@@ -17,6 +17,25 @@ namespace KitchenMysteryMenu.Utils
 
         public static string DishCardDoNotAddFlavorText = "(alsoAddsRecipes card, do not add with Cards Manager)";
 
+        // Sprites, colors, and colorized text
+        public static string SpriteCake = "<sprite name=\"cake\">";//"<nobr><space=-0.2em><sprite name=\"cake\" tint=1>Cake</nobr>";
+        public static string SpriteCakeTint1 = "<sprite name=\"cake\" tint=1>";
+        public static string SpriteFillCoffee = "<sprite name=\"fill_coffee\">";
+        public static string SpriteFillCoffeeTint1 = "<sprite name=\"fill_coffee\" tint=1>";
+
+        public static string ColorCakeHex = "#F376D4"; // OFFICIAL FROM DATA
+        public static string ColorHotDrinkHex = "#B8802F"; // Specific to this mod
+
+        public static string PinkTintCakeText = "$cake$";
+        public static string PinkTintCakesText = "$cakes$";
+        public static string ColorTextCakeBatter = MysteryDishUtils.ColorizeSpriteTextToCake("Cake Batter");
+        public static string ColorTextCakeFlavour = MysteryDishUtils.ColorizeSpriteTextToCake("Cake Flavour");
+        public static string ColorTextCakeFlavours = MysteryDishUtils.ColorizeSpriteTextToCake("Cake Flavours");
+        public static string ColorTextCakeForm = MysteryDishUtils.ColorizeSpriteTextToCake("Cake Form");
+        public static string ColorTextCakeForms = MysteryDishUtils.ColorizeSpriteTextToCake("Cake Forms");
+        public static string ColorTextHotDrink = MysteryDishUtils.ColorizeSpriteTextToHotDrink("Hot Drink");
+        public static string ColorTextHotDrinks = MysteryDishUtils.ColorizeSpriteTextToHotDrink("Hot Drinks");
+
         // Temporary until KitchenLib updates w/ Spaghetti
         public static int SpaghettiBaseDish = 1764920765;
         public static int SpaghettiBologneseDish = -1501485763;


### PR DESCRIPTION
Adds non-main phases and corresponding dishes & cards
* All Sides, all Starters, and most Desserts have been added at this point, as well as the ability for those phases to always be accounted for whenever any are available.
* Adds new provider type: Mystery Tray. For things that get randomized but should only have one of it available on a given day (can still freeze them like normal). Mostly for Coffee/Cakes, though will be useful for Lasagna, too.