### PR TITLE
Fixes HQ Kitchen so that it works as expected

### DIFF
--- a/Systems/RebuildMysteryKitchen.cs
+++ b/Systems/RebuildMysteryKitchen.cs
@@ -2,6 +2,7 @@
 using Kitchen;
 using KitchenLib.References;
 using KitchenMysteryMenu.Components;
+using KitchenMysteryMenu.Customs.Dishes;
 using KitchenMysteryMenu.Utils;
 using System;
 using System.Collections.Generic;
@@ -15,12 +16,20 @@ namespace KitchenMysteryMenu.Systems
 {
     internal class RebuildMysteryKitchen : FranchiseSystem
     {
+        private string LogMsgPrefix = "[RebuildMysteryKitchen]";
+
         private EntityQuery HqItemProviders;
+        private EntityQuery FranchiseMenuItems;
+        private EntityQuery FranchiseMenuOptions;
 
         protected override void Initialise()
         {
             base.Initialise();
             HqItemProviders = GetEntityQuery(typeof(RebuildKitchen.CFranchiseKitchenAppliance), typeof(CItemProvider));
+            FranchiseMenuItems = GetEntityQuery(typeof(RebuildKitchen.CFranchiseKitchenMenuItem), typeof(CMenuItem));
+            FranchiseMenuOptions = GetEntityQuery(new QueryHelper()
+                .All(typeof(RebuildKitchen.CFranchiseKitchenMenuItem), typeof(CAvailableIngredient))
+                .None(typeof(CMenuItem)));
             RequireSingletonForUpdate<RebuildKitchen.SCurrentKitchen>();
         }
 
@@ -31,7 +40,7 @@ namespace KitchenMysteryMenu.Systems
 
             if (!TryGetSingleton<RebuildKitchen.SCurrentKitchen>(out var sCurrentKitchen))
             {
-                Mod.Logger.LogInfo("RebuildMysteryKitchen - SCurrentKitchen not created yet.");
+                Mod.Logger.LogInfo($"{LogMsgPrefix} - SCurrentKitchen not created yet.");
                 return;
             }
             int currentDish = sCurrentKitchen.Dish;
@@ -55,8 +64,111 @@ namespace KitchenMysteryMenu.Systems
 
             // Finally, actually update the mystery providers to (TODO: randomize and) set the ingredients so that they're
             //  vanilla ingredients and not the Mystery placeholders.
-            UpdateMysteryIngredients();
+            AddMysteryMenuComponents(currentDish);
+            //UpdateMysteryIngredients();
+            SelectMysteryMenuOfDay selectMysteryMenuOfDayService = World.GetExistingSystem<SelectMysteryMenuOfDay>();
+            selectMysteryMenuOfDayService.CreateMysteryMenu();
             Mod.Logger.LogInfo("RebuildMysteryKitchen - Done updating ingredients");
+        }
+
+        private void AddMysteryMenuComponents(int currentDishID)
+        {
+            Mod.Logger.LogInfo($"{LogMsgPrefix} - AddMysteryMenuComponents start");
+            using var franchiseMenuEntities = FranchiseMenuItems.ToEntityArray(Allocator.Temp);
+            using var franchiseMenuItemComps = FranchiseMenuItems.ToComponentDataArray<CMenuItem>(Allocator.Temp);
+            using var franchiseMenuOptionEntities = FranchiseMenuOptions.ToEntityArray(Allocator.Temp);
+            using var franchiseMenuOptionComps = FranchiseMenuOptions.ToComponentDataArray<CAvailableIngredient>(Allocator.Temp);
+
+            GenericMysteryDishCard dishCard = MysteryDishCrossReference.GetMysteryCardById(currentDishID);
+
+            // Go through each contained mystery dish, making sure to only use each resulting menu item and
+            //  option once by checking against its source dish id to ensure it's not still the card's id
+            foreach (GenericMysteryDish mysteryDish in dishCard.ContainedMysteryRecipes)
+            {
+                Mod.Logger.LogInfo($"{LogMsgPrefix} - AddMysteryMenuComponents() - Starting dish {{{mysteryDish.UniqueNameID}}} with " +
+                    $"{{ResultingMenuItems.Count = {mysteryDish.ResultingMenuItems.Count}}} and " +
+                    $"{{IngredientsUnlocks.Count = {mysteryDish.IngredientsUnlocks.Count}}}");
+                int menuItemCount = 0;
+                int attempts = 0;
+                bool allFound = false;
+                while (menuItemCount < mysteryDish.ResultingMenuItems.Count)
+                {
+                    attempts++;
+                    for (int i = 0; i < franchiseMenuEntities.Length; i++)
+                    {
+                        Entity entity = franchiseMenuEntities[i];
+                        CMenuItem cMenuItem = franchiseMenuItemComps[i];
+
+                        // Skip this entity if it has already been assigned its recipe or does not have a
+                        //  matching menu item in the current recipe. Franchise kitchen CMenuItem's source dishes
+                        //  are 0's by default.
+                        if ((cMenuItem.SourceDish != dishCard.GameDataObject.ID && cMenuItem.SourceDish != 0) || 
+                            !mysteryDish.ResultingMenuItems.Any(mItem => mItem.Item.ID == cMenuItem.Item))
+                        {
+                            continue;
+                        }
+
+                        int mysteryDishGDOId = mysteryDish.GameDataObject.ID;
+                        cMenuItem.SourceDish = mysteryDishGDOId;
+                        EntityManager.AddComponentData(entity, cMenuItem);
+                        EntityManager.AddComponentData(entity, new CMysteryMenuItem()
+                        {
+                            SourceMysteryDish = mysteryDishGDOId,
+                            Type = MysteryMenuType.Mystery,
+                            HasBeenProvided = false
+                        });
+                        menuItemCount++;
+                        if (menuItemCount >= mysteryDish.ResultingMenuItems.Count)
+                        {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} - Found all CMenuItems for recipe {{{mysteryDish.UniqueNameID}}}");
+                            allFound = true;
+                            break;
+                        }
+                    }
+                    if (!allFound && attempts >= 3)
+                    {
+                        Mod.Logger.LogWarning($"{LogMsgPrefix} - FAILED to find all CMenuItems for recipe {{{mysteryDish.UniqueNameID}}}");
+                        break;
+                    }
+                }
+                int menuOptionCount = 0;
+                attempts = 0;
+                allFound = false;
+                while (menuOptionCount < mysteryDish.IngredientsUnlocks.Count)
+                {
+                    attempts++;
+                    for (int i = 0; i < franchiseMenuOptionEntities.Length; i++)
+                    {
+                        Entity entity = franchiseMenuOptionEntities[i];
+                        CAvailableIngredient cAvailableIngredient = franchiseMenuOptionComps[i];
+
+                        // Skip this entity if it isn't a match (Menu Options don't have duplicates)
+                        if (!mysteryDish.IngredientsUnlocks.Any(ui => ui.MenuItem.ID == cAvailableIngredient.MenuItem && ui.Ingredient.ID == cAvailableIngredient.Ingredient))
+                        {
+                            continue;
+                        }
+
+                        EntityManager.AddComponentData(entity, new CMysteryMenuItem()
+                        {
+                            SourceMysteryDish = mysteryDish.GameDataObject.ID,
+                            Type = MysteryMenuType.Mystery,
+                            HasBeenProvided = false
+                        });
+                        menuOptionCount++;
+                        if (menuOptionCount >= mysteryDish.IngredientsUnlocks.Count)
+                        {
+                            Mod.Logger.LogInfo($"{LogMsgPrefix} - Found all CAvailableIngredients for recipe {{{mysteryDish.UniqueNameID}}}");
+                            allFound = true;
+                            break;
+                        }
+                    }
+                    if (!allFound && attempts >= 3)
+                    {
+                        Mod.Logger.LogInfo($"{LogMsgPrefix} - FAILED to find all CAvailableIngredients for recipe {{{mysteryDish.UniqueNameID}}}");
+                        break;
+                    }
+                }
+            }
         }
 
         private void UpdateMysteryIngredients()


### PR DESCRIPTION
Fixes HQ Kitchen so that it works the same as in-restaurant practice mode

* If the player re-places the menu, then the providers will change up!
* The cat customers will only order what the providers can make, not from the entire Primary Dish Card's recipe list